### PR TITLE
Rollback app0.js + deactivate ajax nav

### DIFF
--- a/CMSBundle/Resources/public/js/app0.js
+++ b/CMSBundle/Resources/public/js/app0.js
@@ -1,121 +1,20 @@
-    
-
-/* ~ END: CHECK MOBILE DEVICE */
-
-/*
- * DOCUMENT LOADED EVENT
- * Description: Fire when DOM is ready
- */
-
-$(document).ready(function() {
-
-    /*
-     * CUSTOM MENU PLUGIN
-     */
-
-    $.fn.extend({
-
-        //pass the options variable to the function
-        jarvismenu : function(options) {
-
-            var defaults = {
-                accordion : 'true',
-                speed : 200,
-                closedSign : '[+]',
-                openedSign : '[-]'
-            };
-
-            // Extend our default options with those provided.
-            var opts = $.extend(defaults, options);
-            //Assign current element to variable, in this case is UL element
-            var $this = $(this);
-
-            //add a mark [+] to a multilevel menu
-            $this.find("li").each(function() {
-                if ($(this).find("ul").size() != 0) {
-                    //add the multilevel sign next to the link
-                    $(this).find("a:first").append("<b class='collapse-sign'>" + opts.closedSign + "</b>");
-
-                    //avoid jumping to the top of the page when the href is an #
-                    if ($(this).find("a:first").attr('href') == "#") {
-                        $(this).find("a:first").click(function() {
-                            return false;
-                        });
-                    }
-                }
-            });
-
-            //open active level
-            $this.find("li.active").each(function() {
-                $(this).parents("ul").slideDown(opts.speed);
-                $(this).parents("ul").parent("li").find("b:first").html(opts.openedSign);
-                $(this).parents("ul").parent("li").addClass("open")
-            });
-
-            $this.find("li a").click(function() {
-
-                if ($(this).parent().find("ul").size() != 0) {
-
-                    if (opts.accordion) {
-                        //Do nothing when the list is open
-                        if (!$(this).parent().find("ul").is(':visible')) {
-                            parents = $(this).parent().parents("ul");
-                            visible = $this.find("ul:visible");
-                            visible.each(function(visibleIndex) {
-                                var close = true;
-                                parents.each(function(parentIndex) {
-                                    if (parents[parentIndex] == visible[visibleIndex]) {
-                                        close = false;
-                                        return false;
-                                    }
-                                });
-                                if (close) {
-                                    if ($(this).parent().find("ul") != visible[visibleIndex]) {
-                                        $(visible[visibleIndex]).slideUp(opts.speed, function() {
-                                            $(this).parent("li").find("b:first").html(opts.closedSign);
-                                            $(this).parent("li").removeClass("open");
-                                        });
-
-                                    }
-                                }
-                            });
-                        }
-                    }// end if
-                    if ($(this).parent().find("ul:first").is(":visible") && !$(this).parent().find("ul:first").hasClass("active")) {
-                        $(this).parent().find("ul:first").slideUp(opts.speed, function() {
-                            $(this).parent("li").removeClass("open");
-                            $(this).parent("li").find("b:first").delay(opts.speed).html(opts.closedSign);
-                        });
-
-                    } else {
-                        $(this).parent().find("ul:first").slideDown(opts.speed, function() {
-                            /*$(this).effect("highlight", {color : '#616161'}, 500); - disabled due to CPU clocking on phones*/
-                            $(this).parent("li").addClass("open");
-                            $(this).parent("li").find("b:first").delay(opts.speed).html(opts.openedSign);
-                        });
-                    } // end else
-                } // end if
-            });
-        } // end function
-    });
-
     /*
      * VARIABLES
      * Description: All Global Vars
      */
     // Impacts the responce rate of some of the responsive elements (lower value affects CPU but improves speed)
     $.throttle_delay = 350;
-
+    
     // The rate at which the menu expands revealing child elements on click
     $.menu_speed = 235;
-
+    
     // Note: You will also need to change this variable in the "variable.less" file.
-    $.navbar_height = 49;
+    $.navbar_height = 49; 
 
     /*
      * APP DOM REFERENCES
      * Description: Obj DOM reference, please try to avoid changing these
-     */
+     */    
     $.root_ = $('body');
     $.left_panel = $('#left-panel');
     $.shortcut_dropdown = $('#shortcut');
@@ -127,12 +26,12 @@ $(document).ready(function() {
     /*
      * APP CONFIGURATION
      * Description: Enable / disable certain theme features here
-     */
-    $.navAsAjax = true; // Your left nav in your app will no longer fire ajax calls
-
+     */        
+    $.navAsAjax = false; // Your left nav in your app will no longer fire ajax calls
+    
     // Please make sure you have included "jarvis.widget.js" for this below feature to work
     $.enableJarvisWidgets = true;
-
+    
     // Warning: Enabling mobile widgets could potentially crash your webApp if you have too many 
     //             widgets running at once (must have $.enableJarvisWidgets = true)
     $.enableMobileWidgets = false;
@@ -142,8 +41,8 @@ $(document).ready(function() {
      * DETECT MOBILE DEVICES
      * Description: Detects mobile device - if any of the listed device is detected
      * a class is inserted to $.root_ and the variable $.device is decleard. 
-     */
-
+     */    
+    
     /* so far this is covering most hand held devices */
     var ismobile = (/iphone|ipad|ipod|android|blackberry|mini|windows\sce|palm/i.test(navigator.userAgent.toLowerCase()));
 
@@ -155,12 +54,20 @@ $(document).ready(function() {
         // Mobile
         $.root_.addClass("mobile-detected");
         $.device = "mobile";
-
+        
         // Removes the tap delay in idevices
         // dependency: js/plugin/fastclick/fastclick.js 
         // FastClick.attach(document.body);
     }
 
+/* ~ END: CHECK MOBILE DEVICE */
+
+/*
+ * DOCUMENT LOADED EVENT
+ * Description: Fire when DOM is ready
+ */
+
+$(document).ready(function() {
     /*
      * Fire tooltips
      */
@@ -531,7 +438,95 @@ var ie = ( function() {
 
 /* ~ END: DETECT IE VERSION */
 
+/*
+ * CUSTOM MENU PLUGIN
+ */
 
+$.fn.extend({
+
+    //pass the options variable to the function
+    jarvismenu : function(options) {
+
+        var defaults = {
+            accordion : 'true',
+            speed : 200,
+            closedSign : '[+]',
+            openedSign : '[-]'
+        };
+
+        // Extend our default options with those provided.
+        var opts = $.extend(defaults, options);
+        //Assign current element to variable, in this case is UL element
+        var $this = $(this);
+
+        //add a mark [+] to a multilevel menu
+        $this.find("li").each(function() {
+            if ($(this).find("ul").size() != 0) {
+                //add the multilevel sign next to the link
+                $(this).find("a:first").append("<b class='collapse-sign'>" + opts.closedSign + "</b>");
+
+                //avoid jumping to the top of the page when the href is an #
+                if ($(this).find("a:first").attr('href') == "#") {
+                    $(this).find("a:first").click(function() {
+                        return false;
+                    });
+                }
+            }
+        });
+
+        //open active level
+        $this.find("li.active").each(function() {
+            $(this).parents("ul").slideDown(opts.speed);
+            $(this).parents("ul").parent("li").find("b:first").html(opts.openedSign);
+            $(this).parents("ul").parent("li").addClass("open")
+        });
+
+        $this.find("li a").click(function() {
+
+            if ($(this).parent().find("ul").size() != 0) {
+
+                if (opts.accordion) {
+                    //Do nothing when the list is open
+                    if (!$(this).parent().find("ul").is(':visible')) {
+                        parents = $(this).parent().parents("ul");
+                        visible = $this.find("ul:visible");
+                        visible.each(function(visibleIndex) {
+                            var close = true;
+                            parents.each(function(parentIndex) {
+                                if (parents[parentIndex] == visible[visibleIndex]) {
+                                    close = false;
+                                    return false;
+                                }
+                            });
+                            if (close) {
+                                if ($(this).parent().find("ul") != visible[visibleIndex]) {
+                                    $(visible[visibleIndex]).slideUp(opts.speed, function() {
+                                        $(this).parent("li").find("b:first").html(opts.closedSign);
+                                        $(this).parent("li").removeClass("open");
+                                    });
+
+                                }
+                            }
+                        });
+                    }
+                }// end if
+                if ($(this).parent().find("ul:first").is(":visible") && !$(this).parent().find("ul:first").hasClass("active")) {
+                    $(this).parent().find("ul:first").slideUp(opts.speed, function() {
+                        $(this).parent("li").removeClass("open");
+                        $(this).parent("li").find("b:first").delay(opts.speed).html(opts.closedSign);
+                    });
+
+                } else {
+                    $(this).parent().find("ul:first").slideDown(opts.speed, function() {
+                        /*$(this).effect("highlight", {color : '#616161'}, 500); - disabled due to CPU clocking on phones*/
+                        $(this).parent("li").addClass("open");
+                        $(this).parent("li").find("b:first").delay(opts.speed).html(opts.openedSign);
+                    });
+                } // end else
+            } // end if
+        });
+    } // end function
+});
 
 /* ~ END: CUSTOM MENU PLUGIN */
 


### PR DESCRIPTION
Retour sur l'app0.js d'origine (delta remplacement des tab par des espaces).
On n'a pas d'autre choix pour désactiver la nav ajax smartadmin que de reparamétrer le setting $.navAsAjax directement dans ce fichier. Mais vu l'indentation des paramètres par rapport au reste du fichier, je suspecte que la conf ait été ajoutée par nos prédecesseurs directement dans ce fichier plutôt que d'être décrite dans un autre. A voir quand on aura un package propre de smartAdmin.
