### PR TITLE
Add get method to ajax-loader

### DIFF
--- a/CMSBundle/Resources/public/js/phporchestra.js
+++ b/CMSBundle/Resources/public/js/phporchestra.js
@@ -59,14 +59,23 @@ function displayLoader()
 }
 
 // Specific orchestra ajax loading
-function orchestraAjaxLoad(url)
+function orchestraAjaxLoad(url, method)
 {
     displayLoader();
-    $.post(url, function(response) {
-        if (response.success) {
-            window.location.hash = response.data;
-        } else {
-            $('#content').html(response);
+    
+    if (method == undefined) {
+        method = 'POST';
+    }
+    
+    $.ajax({
+        url: url,
+        type: method,
+        success: function(response) {
+            if (response.success) {
+                window.location.hash = response.data;
+            } else {
+                $('#content').html(response);
+            }
         }
     });
 }


### PR DESCRIPTION
Cette PR permet d'utiliser la méthode Get plutôt que Post quand on utilise la méthode orchestraAjaxLoad, notamment utile pour pourvoir atteindre les routes de translationBundle qui limitent les protocoles autorisés.
