### PR TITLE
Remove menu entry

### DIFF
--- a/BackofficeBundle/Resources/views/BackOffice/Include/leftMenu.html.twig
+++ b/BackofficeBundle/Resources/views/BackOffice/Include/leftMenu.html.twig
@@ -1,9 +1,6 @@
 <nav data-url="{{ path('php_orchestra_backoffice_menu') }}">
     <ul>
         <li>
-            <a href="javascript:displayMenu();">#Test menu refresh#</a>
-        </li>
-        <li>
             <a href="#">
                 <i class="fa fa-lg fa-fw fa-edit"></i>
                 <span class="menu-item-parent">{{ 'php_orchestra_backoffice.left_menu.editorial.title'|trans }}</span>


### PR DESCRIPTION
Pour tester, déplier le menu de gauche sur n'importe quel élément de n'importe quelle profondeur dans Editorial ou Administration et dans une console javascript lancer displayMenu();
Le menu doit se réafficher et se réouvrir dans le même état.
