### PR TITLE
fixe background for modal

### DIFF
--- a/BackofficeBundle/Resources/public/coffee/orchestraListeners.coffee
+++ b/BackofficeBundle/Resources/public/coffee/orchestraListeners.coffee
@@ -8,3 +8,7 @@ $(".widget-grid").DOMNodeAppear ->
 $(".page-title").DOMNodeAppear ->
   renderPageTitle()
   return
+
+$("#OrchestraBOModal .modal-dialog").on "resize", (e) ->
+  $(this).prev().height($(this).parent().height())
+  return


### PR DESCRIPTION
Il n'est pas possible de passer le fond en fixed, sinon il passe au dessus du scroll de la modal au moins sous FF. J'ai donc essayé de faire le js le plus light possible pour y remédier.
