### PR TITLE
Filter tinyMce init on blockType

### DIFF
--- a/BackofficeBundle/Resources/views/Editorial/template.html.twig
+++ b/BackofficeBundle/Resources/views/Editorial/template.html.twig
@@ -4,6 +4,9 @@
 
 {% if blockType is defined %}
     <span class="orchestra-hidden-info" id="dynamic-modal-title">{{ ('php_orchestra_backoffice.block.' ~ blockType ~ '.title') | trans }}</span>
+
+    {% if blockType in ['tiny_mce_wysiwyg'] %}
+        {{ tinymce_init() }}
+    {% endif %}
 {% endif %}
 
-{{ tinymce_init() }}


### PR DESCRIPTION
@nicolasThal , @itkg-bfouche , @itkg-nanne : Cette PR doit résoudre le problème de l'initialisation systématique du tinyMce en ne la déclenchant que pour les blocs qui la nécessitent.

Par contre je n'aime pas du tout la façon dont je la réalise pour le moment, le tableau qui contient la liste des blocs concernés étant fixé en dur dans le twig. Avez-vous des suggestions pour un paramétrage externe ?
