### PR TITLE
fix content submission with multiselect field

### DIFF
--- a/BackofficeBundle/EventSubscriber/ContentTypeSubscriber.php
+++ b/BackofficeBundle/EventSubscriber/ContentTypeSubscriber.php
@@ -66,6 +66,7 @@ class ContentTypeSubscriber extends AbstractModulableTypeSubscriber
             $content->setContentTypeVersion($contentType->getVersion());
             foreach ($contentType->getFields() as $contentTypeField) {
                 $contentTypeFieldId = $contentTypeField->getFieldId();
+                $data[$contentTypeFieldId] = isset($data[$contentTypeFieldId]) ? $data[$contentTypeFieldId] : null;
                 if ($attribute = $content->getAttributeByName($contentTypeFieldId)) {
                     $attribute->setValue($this->transformData($data[$contentTypeFieldId], $form->get($contentTypeFieldId)));
                 } elseif (is_null($attribute)) {


### PR DESCRIPTION
When using a multiselect form field and the user does not select any value, the field is not posted by the browser. This case was not managed.