### PR TITLE
fix form submission in FullPageFormView

### DIFF
--- a/BackofficeBundle/Resources/public/coffee/FullPageFormView.coffee
+++ b/BackofficeBundle/Resources/public/coffee/FullPageFormView.coffee
@@ -33,7 +33,7 @@ FullPageFormView = OrchestraView.extend(
     event.preventDefault()
     viewContext = @
     viewClass = appConfigurationView.getConfiguration(@options.entityType, 'editEntity')
-    $("form", @$el).ajaxSubmit
+    $(event.target).ajaxSubmit
       context: button: $(".submit_form",event.target).parent()
       success: (response) ->
         new viewClass(viewContext.addOption(


### PR DESCRIPTION
If the FullPageFormView has multiple form in it, it will always submit the first one no matter what.
As we have direct access to the actually submitted form, I use it in the jQuery selector.