### PR TITLE
fix NodeGroupRole creation when it already exists

### DIFF
--- a/BackofficeBundle/Model/GroupInterface.php
+++ b/BackofficeBundle/Model/GroupInterface.php
@@ -62,4 +62,12 @@ interface GroupInterface extends BaseGroupInterface, TranslatedValueContainerInt
      * @return NodeGroupRoleInterface|null
      */
     public function getNodeRoleByNodeAndRole($nodeId, $role);
+
+    /**
+     * @param string $nodeId
+     * @param string $role
+     *
+     * @return boolean
+     */
+    public function hasNodeRoleByNodeAndRole($nodeId, $role);
 }

--- a/GroupBundle/Document/Group.php
+++ b/GroupBundle/Document/Group.php
@@ -163,4 +163,15 @@ class Group extends BaseGroup implements GroupInterface
 
         return null;
     }
+
+    /**
+     * @param string $nodeId
+     * @param string $role
+     *
+     * @return boolean
+     */
+    public function hasNodeRoleByNodeAndRole($nodeId, $role)
+    {
+        return null !== $this->getNodeRoleByNodeAndRole($nodeId, $role);
+    }
 }

--- a/GroupBundle/EventListener/AddNodeGroupRoleForNodeListener.php
+++ b/GroupBundle/EventListener/AddNodeGroupRoleForNodeListener.php
@@ -26,10 +26,12 @@ class AddNodeGroupRoleForNodeListener extends AbstractNodeGroupRoleListener
             foreach ($groups as $group) {
                 if ($siteId === $group->getSite()->getSiteId()) {
                     foreach ($nodesRoles as $role => $translation) {
-                        $nodeGroupRole = $this->createNodeGroupRole($document, $group, $role, $accessType);
-                        $group->addNodeRole($nodeGroupRole);
-                        $event->getDocumentManager()->persist($group);
-                        $event->getDocumentManager()->flush($group);
+                        if (false === $group->hasNodeRoleByNodeAndRole($document->getNodeId(), $role)) {
+                            $nodeGroupRole = $this->createNodeGroupRole($document, $group, $role, $accessType);
+                            $group->addNodeRole($nodeGroupRole);
+                            $event->getDocumentManager()->persist($group);
+                            $event->getDocumentManager()->flush($group);
+                        }
                     }
                 }
             }

--- a/GroupBundle/Tests/EventListener/AbstractNodeGroupRoleListenerTest.php
+++ b/GroupBundle/Tests/EventListener/AbstractNodeGroupRoleListenerTest.php
@@ -36,6 +36,7 @@ abstract class AbstractNodeGroupRoleListenerTest extends AbstractBaseTestCase
         $parentNodeGroupRole = Phake::mock('OpenOrchestra\BackofficeBundle\Model\NodeGroupRoleInterface');
         phake::when($parentNodeGroupRole)->isGranted()->thenReturn(true);
         phake::when($group)->getNodeRoleByNodeAndRole(Phake::anyParameters())->thenReturn($parentNodeGroupRole);
+        phake::when($group)->hasNodeRoleByNodeAndRole(Phake::anyParameters())->thenReturn(false);
 
         $site = Phake::mock('OpenOrchestra\ModelInterface\Model\SiteInterface');
         Phake::when($group)->getSite()->thenReturn($site);

--- a/GroupBundle/Tests/EventListener/AddNodeGroupRoleForNodeListenerTest.php
+++ b/GroupBundle/Tests/EventListener/AddNodeGroupRoleForNodeListenerTest.php
@@ -65,10 +65,13 @@ class AddNodeGroupRoleForNodeListenerTest extends AbstractNodeGroupRoleListenerT
     {
         $group1 = $this->createMockGroup();
         $group2 = $this->createMockGroup();
+        $group3 = $this->createMockGroup();
+        Phake::when($group3)->hasNodeRoleByNodeAndRole(Phake::anyParameters())->thenReturn(true);
 
         return array(
            array(array($group1, $group2), 2),
            array(array($group1), 1),
+           array(array($group3), 0),
            array(array(), 0),
         );
     }


### PR DESCRIPTION
[OO-BUGFIX] When a node is duplicated there's no more node group role creation