### PR TITLE
fix version backbone, wreqr, jquery-minicolors and merge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
             "coffee-script": "~1.9.1",
             "load-grunt-tasks": "~3.2.0",
             "glob": "~5.0.10",
-            "merge": "*"
+            "merge": "~1.2.0"
         },
         "expose-npm-packages": true,
         "require-bower": {
@@ -70,10 +70,9 @@
             "select2": "3.5.2",
             "font-awesome": "4.3.0",
             "open-sans": "v1.1.0",
-            "backbone": "*",
-            "underscore": "*",
-            "jquery-minicolors": "*",
-            "backbone.wreqr": "*"
+            "backbone": "~1.2.3",
+            "jquery-minicolors": "~2.2.3",
+            "backbone.wreqr": "~1.3.5"
         }
     }
 }


### PR DESCRIPTION
[OO-CONFIGURATION] dependencies version are fixed : ``merge ~1.2.0``, ``backbone ~1.2.3``, ``jquery-minicolors ~2.2.3``, ``backbone.wreqr ~1.3.5``.
[OO-CONFIGURATION] bower dependency ``underscore`` is removed, this package is include by ``backbone``