### PR TITLE
Pass the 'disabled' option to the block form strategy when required

### DIFF
--- a/BackofficeBundle/EventSubscriber/BlockTypeSubscriber.php
+++ b/BackofficeBundle/EventSubscriber/BlockTypeSubscriber.php
@@ -45,7 +45,11 @@ class BlockTypeSubscriber extends AbstractModulableTypeSubscriber
             $data->setLabel($data->getComponent() . ' #' . ($this->blockPosition + 1));
         }
 
-        $newForm = $this->formFactory->create($this->generateFormManager->createForm($data));
+        $newForm = $this->formFactory->create(
+            $this->generateFormManager->createForm($data),
+            null,
+            array('disabled' => $form->isDisabled())
+        );
 
         foreach ($newForm->all() as $newFormChild) {
             $form->add($newFormChild);


### PR DESCRIPTION
[OO-BUGFIX] Pass the 'disabled' option to the block form strategy when required

https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1399
https://github.com/open-orchestra/open-orchestra-media-admin-bundle/pull/137
