### PR TITLE
Move getCacheTags from AbstractStrategy to implementing strategies

### DIFF
--- a/Backoffice/DisplayBlock/Strategies/AddThisStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/AddThisStrategy.php
@@ -42,6 +42,16 @@ class AddThisStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/Backoffice/DisplayBlock/Strategies/AudienceAnalysisStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/AudienceAnalysisStrategy.php
@@ -40,6 +40,16 @@ class AudienceAnalysisStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/Backoffice/DisplayBlock/Strategies/ConfigurableContentStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/ConfigurableContentStrategy.php
@@ -61,6 +61,16 @@ class ConfigurableContentStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/Backoffice/DisplayBlock/Strategies/ContactStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/ContactStrategy.php
@@ -43,6 +43,16 @@ class ContactStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/Backoffice/DisplayBlock/Strategies/ContentListStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/ContentListStrategy.php
@@ -49,6 +49,16 @@ class ContentListStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/Backoffice/DisplayBlock/Strategies/ContentStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/ContentStrategy.php
@@ -44,6 +44,16 @@ class ContentStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/Backoffice/DisplayBlock/Strategies/FooterStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/FooterStrategy.php
@@ -43,6 +43,16 @@ class FooterStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/Backoffice/DisplayBlock/Strategies/GmapStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/GmapStrategy.php
@@ -43,6 +43,16 @@ class GmapStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/Backoffice/DisplayBlock/Strategies/LanguageListStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/LanguageListStrategy.php
@@ -43,6 +43,16 @@ class LanguageListStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/Backoffice/DisplayBlock/Strategies/LoginStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/LoginStrategy.php
@@ -38,6 +38,16 @@ class LoginStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/Backoffice/DisplayBlock/Strategies/MenuStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/MenuStrategy.php
@@ -43,6 +43,16 @@ class MenuStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/Backoffice/DisplayBlock/Strategies/SearchResultStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/SearchResultStrategy.php
@@ -47,6 +47,16 @@ class SearchResultStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/Backoffice/DisplayBlock/Strategies/SearchStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/SearchStrategy.php
@@ -47,6 +47,16 @@ class SearchStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/Backoffice/DisplayBlock/Strategies/SubMenuStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/SubMenuStrategy.php
@@ -45,6 +45,16 @@ class SubMenuStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/Backoffice/DisplayBlock/Strategies/TinyMCEWysiwygStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/TinyMCEWysiwygStrategy.php
@@ -42,6 +42,16 @@ class TinyMCEWysiwygStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/Backoffice/DisplayBlock/Strategies/VideoStrategy.php
+++ b/Backoffice/DisplayBlock/Strategies/VideoStrategy.php
@@ -40,6 +40,16 @@ class VideoStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string


### PR DESCRIPTION
[OO-BCBREAK] DisplayBundle/DisplayBlock/Strategies/AbstractStrategy:getCacheTags() is now abstract and must therefore be explicitally implemented on each display strategy
https://github.com/open-orchestra/open-orchestra-display-bundle/pull/200
https://github.com/open-orchestra/open-orchestra-media-bundle/pull/166
https://github.com/open-orchestra/open-orchestra-elastica-bundle/pull/17
https://github.com/open-orchestra/open-orchestra-elastica-bundle/pull/18
https://github.com/open-orchestra/open-orchestra-media-admin-bundle/pull/159
https://github.com/open-orchestra/open-orchestra-user-bundle/pull/92
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1457