### PR TITLE
hide rootmenu if not submenu

### DIFF
--- a/BackofficeBundle/Resources/views/BackOffice/Include/NavigationPanel/show.html.twig
+++ b/BackofficeBundle/Resources/views/BackOffice/Include/NavigationPanel/show.html.twig
@@ -3,24 +3,22 @@
         {% for rootMenuWeights in strategies[navigation_panel.root_menu] %}
             {% for rootMenu in rootMenuWeights %}
 
-                {% set treeRootMenu = '' %}
-                {% if strategies[rootMenu.name] is defined %}
-                    {% for subMenuWeights in strategies[rootMenu.name] %}
-                        {% for subMenu in subMenuWeights %}
-                            {% if is_granted(subMenu.getRole) %}
-                                {% set treeRootMenu = treeRootMenu ~ ' <li>' %}
-                                {% set treeRootMenu = treeRootMenu ~ subMenu.show %}
-                                {% set treeRootMenu = treeRootMenu ~ ' </li>' %}
-                            {% endif %}
+                {% set treeRootMenu %}{% if strategies[rootMenu.name] is defined %}
+                        {% for subMenuWeights in strategies[rootMenu.name] %}
+                            {% for subMenu in subMenuWeights %}
+                                {% if is_granted(subMenu.getRole) %}
+                                    <li>
+                                        {{ subMenu.show|raw }}
+                                    </li>
+                                {% endif %}
+                            {% endfor %}
                         {% endfor %}
-                    {% endfor %}
-                {% endif %}
-
+                    {% endif %}{% endset %}
                 {% if not strategies[rootMenu.name] is defined  %}
                     <li>
                         {{ rootMenu.show|raw }}
                     </li>
-                {% elseif not treeRootMenu is empty %}
+                {% elseif not treeRootMenu|trim is empty %}
                     <li>
                         {{ rootMenu.show|raw }}
                         <ul>

--- a/BackofficeBundle/Resources/views/BackOffice/Include/NavigationPanel/show.html.twig
+++ b/BackofficeBundle/Resources/views/BackOffice/Include/NavigationPanel/show.html.twig
@@ -2,22 +2,33 @@
     <ul>
         {% for rootMenuWeights in strategies[navigation_panel.root_menu] %}
             {% for rootMenu in rootMenuWeights %}
-                <li>
-                    {{ rootMenu.show|raw }}
-                    {% if strategies[rootMenu.name] is defined %}
+
+                {% set treeRootMenu = '' %}
+                {% if strategies[rootMenu.name] is defined %}
+                    {% for subMenuWeights in strategies[rootMenu.name] %}
+                        {% for subMenu in subMenuWeights %}
+                            {% if is_granted(subMenu.getRole) %}
+                                {% set treeRootMenu = treeRootMenu ~ ' <li>' %}
+                                {% set treeRootMenu = treeRootMenu ~ subMenu.show %}
+                                {% set treeRootMenu = treeRootMenu ~ ' </li>' %}
+                            {% endif %}
+                        {% endfor %}
+                    {% endfor %}
+                {% endif %}
+
+                {% if not strategies[rootMenu.name] is defined  %}
+                    <li>
+                        {{ rootMenu.show|raw }}
+                    </li>
+                {% elseif not treeRootMenu is empty %}
+                    <li>
+                        {{ rootMenu.show|raw }}
                         <ul>
-                            {% for subMenuWeights in strategies[rootMenu.name] %}
-                                {% for subMenu in subMenuWeights %}
-                                    {% if is_granted(subMenu.getRole) %}
-                                        <li>
-                                            {{ subMenu.show|raw }}
-                                        </li>
-                                    {% endif %}
-                                {% endfor %}
-                            {% endfor %}
+                            {{ treeRootMenu|raw }}
                         </ul>
-                    {% endif %}
-                </li>
+                    </li>
+                {% endif %}
+
             {% endfor %}
         {% endfor %}
     </ul>

--- a/BackofficeBundle/Resources/views/BackOffice/Include/NavigationPanel/show.html.twig
+++ b/BackofficeBundle/Resources/views/BackOffice/Include/NavigationPanel/show.html.twig
@@ -3,7 +3,8 @@
         {% for rootMenuWeights in strategies[navigation_panel.root_menu] %}
             {% for rootMenu in rootMenuWeights %}
 
-                {% set treeRootMenu %}{% if strategies[rootMenu.name] is defined %}
+                {% set treeRootMenu %}
+                    {% if strategies[rootMenu.name] is defined %}
                         {% for subMenuWeights in strategies[rootMenu.name] %}
                             {% for subMenu in subMenuWeights %}
                                 {% if is_granted(subMenu.getRole) %}
@@ -13,7 +14,9 @@
                                 {% endif %}
                             {% endfor %}
                         {% endfor %}
-                    {% endif %}{% endset %}
+                    {% endif %}
+                {% endset %}
+
                 {% if not strategies[rootMenu.name] is defined  %}
                     <li>
                         {{ rootMenu.show|raw }}


### PR DESCRIPTION
[OO-BUGFIX] In navigation panel, a root menu is hidden if these submenus aren't visible