### PR TITLE
rename move tree

### DIFF
--- a/ApiBundle/Controller/NodeController.php
+++ b/ApiBundle/Controller/NodeController.php
@@ -263,7 +263,7 @@ class NodeController extends BaseController
     public function updateChildrenOrderAction(Request $request, $nodeId)
     {
         $node = $this->get('open_orchestra_model.repository.node')->findOneByNodeId($nodeId);
-        $this->denyAccessUnlessGranted(TreeNodesPanelStrategy::ROLE_ACCESS_MOVE_NODE, $node);
+        $this->denyAccessUnlessGranted(TreeNodesPanelStrategy::ROLE_ACCESS_MOVE_TREE);
         $facade = $this->get('jms_serializer')->deserialize(
             $request->getContent(),
             'OpenOrchestra\ApiBundle\Facade\NodeCollectionFacade',

--- a/Backoffice/NavigationPanel/Strategies/TreeNodesPanelStrategy.php
+++ b/Backoffice/NavigationPanel/Strategies/TreeNodesPanelStrategy.php
@@ -15,7 +15,7 @@ class TreeNodesPanelStrategy extends AbstractNavigationPanelStrategy
     const ROLE_ACCESS_CREATE_NODE = 'ROLE_ACCESS_CREATE_NODE';
     const ROLE_ACCESS_UPDATE_NODE = 'ROLE_ACCESS_UPDATE_NODE';
     const ROLE_ACCESS_DELETE_NODE = 'ROLE_ACCESS_DELETE_NODE';
-    const ROLE_ACCESS_MOVE_NODE = 'ROLE_ACCESS_MOVE_NODE';
+    const ROLE_ACCESS_MOVE_TREE = 'ROLE_ACCESS_MOVE_TREE';
 
     /**
      * @var NodeRepositoryInterface

--- a/Backoffice/Security/Authorization/Voter/StatusableVoter.php
+++ b/Backoffice/Security/Authorization/Voter/StatusableVoter.php
@@ -25,7 +25,7 @@ class StatusableVoter implements VoterInterface
         && false === strpos($attribute, 'ROLE_ACCESS_TREE_NODE')
         && false === strpos($attribute, 'ROLE_ACCESS_CREATE_NODE')
         && false === strpos($attribute, 'ROLE_ACCESS_DELETE_NODE')
-        && false === strpos($attribute, 'ROLE_ACCESS_MOVE_NODE');
+        && false === strpos($attribute, 'ROLE_ACCESS_MOVE_TREE');
     }
 
     /**

--- a/Backoffice/Tests/Security/Authorization/Voter/StatusableVoterTest.php
+++ b/Backoffice/Tests/Security/Authorization/Voter/StatusableVoterTest.php
@@ -59,7 +59,7 @@ class StatusableVoterTest extends AbstractBaseTestCase
             array(false, 'ROLE_ACCESS_TREE_NODE'),
             array(false, 'ROLE_ACCESS_CREATE_NODE'),
             array(false, 'ROLE_ACCESS_DELETE_NODE'),
-            array(false, 'ROLE_ACCESS_MOVE_NODE'),
+            array(false, 'ROLE_ACCESS_MOVE_TREE'),
             array(false, '24051'),
             array(false, 'foo'),
         );

--- a/BackofficeBundle/DependencyInjection/Compiler/RoleCompilerPass.php
+++ b/BackofficeBundle/DependencyInjection/Compiler/RoleCompilerPass.php
@@ -78,7 +78,7 @@ class RoleCompilerPass extends AbstractRoleCompilerPass
             TreeNodesPanelStrategy::ROLE_ACCESS_CREATE_NODE,
             TreeNodesPanelStrategy::ROLE_ACCESS_UPDATE_NODE,
             TreeNodesPanelStrategy::ROLE_ACCESS_DELETE_NODE,
-            TreeNodesPanelStrategy::ROLE_ACCESS_MOVE_NODE,
+            TreeNodesPanelStrategy::ROLE_ACCESS_MOVE_TREE,
             AdministrationPanelStrategy::ROLE_ACCESS_SITE,
             AdministrationPanelStrategy::ROLE_ACCESS_CREATE_SITE,
             AdministrationPanelStrategy::ROLE_ACCESS_UPDATE_SITE,

--- a/BackofficeBundle/Resources/translations/role.en.yml
+++ b/BackofficeBundle/Resources/translations/role.en.yml
@@ -6,7 +6,7 @@ open_orchestra_role:
     role_access_create_node: Create a page
     role_access_update_node: Update a page
     role_access_delete_node: Delete a page
-    role_access_move_node: Move a page
+    role_access_move_tree: Move a page
     role_access_tree_template: Access page templates
     role_access_create_template: Create a page template
     role_access_update_template: Update a page template

--- a/BackofficeBundle/Resources/translations/role.fr.yml
+++ b/BackofficeBundle/Resources/translations/role.fr.yml
@@ -6,7 +6,7 @@ open_orchestra_role:
     role_access_create_node: Créer une page
     role_access_update_node: Editer une page
     role_access_delete_node: Supprimer une page
-    role_access_move_node: Déplacer une page
+    role_access_move_tree: Déplacer une page
     role_access_tree_template: Accéder aux gabarits de pages
     role_access_create_template: Créer un gabarit de page
     role_access_update_template: Modifier un gabarit de page

--- a/BackofficeBundle/Resources/views/Tree/tree-macros.html.twig
+++ b/BackofficeBundle/Resources/views/Tree/tree-macros.html.twig
@@ -19,7 +19,7 @@
                    and node.nodeType != constant('TYPE_TRANSVERSE', node)
                 %}
                     <ul
-                        {% if is_granted("ROLE_ACCESS_MOVE_NODE", node) %} class="node-connectedSortable" {% endif %}
+                        {% if is_granted("ROLE_ACCESS_MOVE_TREE") %} class="node-connectedSortable" {% endif %}
                         data-update-order="{{ path('open_orchestra_api_node_update_children_order', {'nodeId': node.nodeId}) }}"
                         data-confirm-title="{{ 'open_orchestra_backoffice.left_menu.tree.confirm_move.title'|trans }}"
                         data-confirm-text="{{ 'open_orchestra_backoffice.left_menu.tree.confirm_move.text'|trans({'%nodeName%': node.name}) }}"

--- a/GroupBundle/DataFixtures/MongoDB/AbstractLoadGroupData.php
+++ b/GroupBundle/DataFixtures/MongoDB/AbstractLoadGroupData.php
@@ -61,7 +61,7 @@ abstract class AbstractLoadGroupData extends AbstractFixture implements OrderedF
             $group->addRole(TreeNodesPanelStrategy::ROLE_ACCESS_UPDATE_NODE);
             $group->addRole(TreeNodesPanelStrategy::ROLE_ACCESS_CREATE_NODE);
             $group->addRole(TreeNodesPanelStrategy::ROLE_ACCESS_DELETE_NODE);
-            $group->addRole(TreeNodesPanelStrategy::ROLE_ACCESS_MOVE_NODE);
+            $group->addRole(TreeNodesPanelStrategy::ROLE_ACCESS_MOVE_TREE);
             $group->addRole(TreeTemplatePanelStrategy::ROLE_ACCESS_TREE_TEMPLATE);
             $group->addRole(TreeTemplatePanelStrategy::ROLE_ACCESS_CREATE_TEMPLATE);
             $group->addRole(TreeTemplatePanelStrategy::ROLE_ACCESS_UPDATE_TEMPLATE);


### PR DESCRIPTION
[OO-MISC] role ``ROLE_ACCESS_MOVE_NODE`` is renamed to ``ROLE_ACCESS_MOVE_TREE`` and is now a global role