### PR TITLE
send only when document is valid

### DIFF
--- a/BackofficeBundle/Controller/ContentTypeController.php
+++ b/BackofficeBundle/Controller/ContentTypeController.php
@@ -35,8 +35,9 @@ class ContentTypeController extends AbstractAdminController
 
         $form->handleRequest($request);
         if ('PATCH' !== $request->getMethod()) {
-            $this->handleForm($form, $this->get('translator')->trans('open_orchestra_backoffice.form.content_type.success'), $newContentType);
-            $this->dispatchEvent(ContentTypeEvents::CONTENT_TYPE_UPDATE, new ContentTypeEvent($newContentType));
+            if ($this->handleForm($form, $this->get('translator')->trans('open_orchestra_backoffice.form.content_type.success'), $newContentType)) {
+                $this->dispatchEvent(ContentTypeEvents::CONTENT_TYPE_UPDATE, new ContentTypeEvent($newContentType));
+            }
         }
 
         return $this->render('OpenOrchestraBackofficeBundle::form.html.twig', array(


### PR DESCRIPTION
[OO-BUGFIX] The event ``ContentTypeEvents::CONTENT_TYPE_UPDATE`` is dispatched only when content type form is valid