### PR TITLE
create root note when site is created

### DIFF
--- a/ApiBundle/Controller/NodeController.php
+++ b/ApiBundle/Controller/NodeController.php
@@ -72,6 +72,7 @@ class NodeController extends BaseController
         }
         if (!$node) {
             $oldNode = $this->findOneNode($nodeId, $currentSiteDefaultLanguage, $siteId);
+
             if ($oldNode) {
                 $this->denyAccessUnlessGranted(TreeNodesPanelStrategy::ROLE_ACCESS_CREATE_NODE, $oldNode);
                 $node = $this->get('open_orchestra_backoffice.manager.node')->createNewLanguageNode($oldNode, $language);

--- a/ApiBundle/Controller/NodeController.php
+++ b/ApiBundle/Controller/NodeController.php
@@ -72,7 +72,6 @@ class NodeController extends BaseController
         }
         if (!$node) {
             $oldNode = $this->findOneNode($nodeId, $currentSiteDefaultLanguage, $siteId);
-
             if ($oldNode) {
                 $this->denyAccessUnlessGranted(TreeNodesPanelStrategy::ROLE_ACCESS_CREATE_NODE, $oldNode);
                 $node = $this->get('open_orchestra_backoffice.manager.node')->createNewLanguageNode($oldNode, $language);

--- a/Backoffice/EventSubscriber/CreateRootNodeSubscriber.php
+++ b/Backoffice/EventSubscriber/CreateRootNodeSubscriber.php
@@ -15,6 +15,8 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class CreateRootNodeSubscriber implements EventSubscriberInterface
 {
+    const ROOT_NODE_PATTERN = '/';
+
     protected $nodeManager;
     protected $repositoryTemplate;
     protected $objectManager;
@@ -31,8 +33,7 @@ class CreateRootNodeSubscriber implements EventSubscriberInterface
         TemplateRepositoryInterface $repositoryTemplate,
         ObjectManager $objectManager,
         TranslatorInterface $translator
-    )
-    {
+    ){
         $this->nodeManager = $nodeManager;
         $this->repositoryTemplate = $repositoryTemplate;
         $this->objectManager = $objectManager;
@@ -44,15 +45,14 @@ class CreateRootNodeSubscriber implements EventSubscriberInterface
      */
     public function createRootNode(SiteEvent $siteEvent)
     {
-        $templateId = $siteEvent->getTemplateIdNodeHome();
+        $templateId = $siteEvent->getRootNodeTemplateId();
         $site = $siteEvent->getSite();
         if (null !== $templateId && null !== $site) {
             $language = $site->getDefaultLanguage();
             $template = $this->repositoryTemplate->findOneByTemplateId($templateId);
             $name = $this->translator->trans('open_orchestra_backoffice.node.root_name');
-            $routePattern = '/';
 
-            $node = $this->nodeManager->createRootNode($site->getSiteId(), $language, $name, $routePattern, $template);
+            $node = $this->nodeManager->createRootNode($site->getSiteId(), $language, $name, self::ROOT_NODE_PATTERN, $template);
             $this->objectManager->persist($node);
             $this->objectManager->flush();
         }

--- a/Backoffice/EventSubscriber/CreateRootNodeSubscriber.php
+++ b/Backoffice/EventSubscriber/CreateRootNodeSubscriber.php
@@ -67,5 +67,4 @@ class CreateRootNodeSubscriber implements EventSubscriberInterface
             SiteEvents::SITE_CREATE => 'createRootNode',
         );
     }
-
 }

--- a/Backoffice/EventSubscriber/CreateRootNodeSubscriber.php
+++ b/Backoffice/EventSubscriber/CreateRootNodeSubscriber.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace OpenOrchestra\Backoffice\EventSubscriber;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use OpenOrchestra\Backoffice\Manager\NodeManager;
+use OpenOrchestra\ModelInterface\Event\SiteEvent;
+use OpenOrchestra\ModelInterface\Repository\TemplateRepositoryInterface;
+use OpenOrchestra\ModelInterface\SiteEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Class CreateRootNodeSubscriber
+ */
+class CreateRootNodeSubscriber implements EventSubscriberInterface
+{
+    protected $nodeManager;
+    protected $repositoryTemplate;
+    protected $objectManager;
+    protected $translator;
+
+    /**
+     * @param NodeManager                 $nodeManager
+     * @param TemplateRepositoryInterface $repositoryTemplate
+     * @param ObjectManager               $objectManager
+     * @param TranslatorInterface         $translator
+     */
+    public function __construct(
+        NodeManager $nodeManager,
+        TemplateRepositoryInterface $repositoryTemplate,
+        ObjectManager $objectManager,
+        TranslatorInterface $translator
+    )
+    {
+        $this->nodeManager = $nodeManager;
+        $this->repositoryTemplate = $repositoryTemplate;
+        $this->objectManager = $objectManager;
+        $this->translator = $translator;
+    }
+
+    /**
+     * @param SiteEvent $siteEvent
+     */
+    public function createRootNode(SiteEvent $siteEvent)
+    {
+        $templateId = $siteEvent->getTemplateIdNodeHome();
+        $site = $siteEvent->getSite();
+        if (null !== $templateId && null !== $site) {
+            $language = $site->getDefaultLanguage();
+            $template = $this->repositoryTemplate->findOneByTemplateId($templateId);
+            $name = $this->translator->trans('open_orchestra_backoffice.node.root_name');
+            $routePattern = '/';
+
+            $node = $this->nodeManager->createRootNode($site->getSiteId(), $language, $name, $routePattern, $template);
+            $this->objectManager->persist($node);
+            $this->objectManager->flush();
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            SiteEvents::SITE_CREATE => 'createRootNode',
+        );
+    }
+
+}

--- a/Backoffice/EventSubscriber/NodeTemplateSelectionSubscriber.php
+++ b/Backoffice/EventSubscriber/NodeTemplateSelectionSubscriber.php
@@ -48,7 +48,7 @@ class NodeTemplateSelectionSubscriber implements EventSubscriberInterface
             ) {
                 $template = $this->templateRepository->findOneByTemplateId($data['nodeTemplateSelection']['templateId']);
                 if (null !== $template) {
-                    $this->hydrateAreaFromTemplate($formData, $template->getAreas());
+                    $this->nodeManager->hydrateAreaFromTemplate($formData, $template->getAreas());
                 }
             } elseif (
                 array_key_exists('nodeSource', $data['nodeTemplateSelection']) &&
@@ -115,20 +115,5 @@ class NodeTemplateSelectionSubscriber implements EventSubscriberInterface
         }
 
         return $templatesChoices;
-    }
-
-    /**
-     * @param AreaContainerInterface $areaContainer
-     * @param Collection             $sourceAreas
-     */
-    protected function hydrateAreaFromTemplate(AreaContainerInterface $areaContainer, $sourceAreas)
-    {
-        foreach($sourceAreas as $area) {
-            $newArea = clone $area;
-            if (!empty($area->getAreas())) {
-                $this->hydrateAreaFromTemplate($newArea, $area->getAreas());
-            }
-            $areaContainer->addArea($newArea);
-        }
     }
 }

--- a/Backoffice/EventSubscriber/WebSiteNodeTemplateSubscriber.php
+++ b/Backoffice/EventSubscriber/WebSiteNodeTemplateSubscriber.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace OpenOrchestra\Backoffice\EventSubscriber;
+
+use OpenOrchestra\ModelInterface\Repository\TemplateRepositoryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * Class WebSiteNodeTemplateSubscriber
+ */
+class WebSiteNodeTemplateSubscriber implements EventSubscriberInterface
+{
+    protected $templateRepository;
+
+    /**
+     * @param TemplateRepositoryInterface $templateRepository
+     */
+    public function __construct(TemplateRepositoryInterface $templateRepository)
+    {
+        $this->templateRepository = $templateRepository;
+    }
+
+    /**
+     * @param FormEvent $event
+     */
+    public function onPreSetData(FormEvent $event)
+    {
+        $form = $event->getForm();
+        $data = $event->getData();
+        if (null === $data->getSiteId()) {
+            $form->add('templateId', 'choice', array(
+                'choices' => $this->getTemplateChoices(),
+                'required' => true,
+                'mapped' => false,
+                'label' => 'open_orchestra_backoffice.form.website.template_node_root.label',
+                'attr'  => array(
+                    'help_text' => 'open_orchestra_backoffice.form.website.template_node_root.helper',
+                )
+            ));
+        }
+    }
+
+    /**
+     *
+     * @return array
+     */
+    protected function getTemplateChoices()
+    {
+        $templates = $this->templateRepository->findByDeleted(false);
+        $templatesChoices = array();
+        foreach ($templates as $template) {
+            $templatesChoices[$template->getTemplateId()] = $template->getName();
+        }
+
+        return $templatesChoices;
+    }
+
+    /**
+     * @return array The event names to listen to
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FormEvents::PRE_SET_DATA => 'onPreSetData',
+        );
+    }
+}

--- a/Backoffice/Form/Type/SiteType.php
+++ b/Backoffice/Form/Type/SiteType.php
@@ -2,7 +2,9 @@
 
 namespace OpenOrchestra\Backoffice\Form\Type;
 
+use OpenOrchestra\Backoffice\EventSubscriber\WebSiteNodeTemplateSubscriber;
 use OpenOrchestra\Backoffice\EventSubscriber\WebSiteSubscriber;
+use OpenOrchestra\ModelInterface\Repository\TemplateRepositoryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -15,15 +17,18 @@ class SiteType extends AbstractType
 {
     protected $siteClass;
     protected $translator;
+    protected $templateRepository;
 
     /**
-     * @param string              $siteClass
-     * @param TranslatorInterface $translator
+     * @param string                      $siteClass
+     * @param TranslatorInterface         $translator
+     * @param TemplateRepositoryInterface $templateRepository
      */
-    public function __construct($siteClass, TranslatorInterface $translator)
+    public function __construct($siteClass, TranslatorInterface $translator, TemplateRepositoryInterface $templateRepository)
     {
         $this->siteClass = $siteClass;
         $this->translator = $translator;
+        $this->templateRepository = $templateRepository;
     }
 
     /**
@@ -94,6 +99,7 @@ class SiteType extends AbstractType
             ))
             ;
         $builder->addEventSubscriber(new WebSiteSubscriber());
+        $builder->addEventSubscriber(new WebSiteNodeTemplateSubscriber($this->templateRepository));
         if (array_key_exists('disabled', $options)) {
             $builder->setAttribute('disabled', $options['disabled']);
         }

--- a/Backoffice/Tests/EventSubscriber/CreateRootNodeSubscriberTest.php
+++ b/Backoffice/Tests/EventSubscriber/CreateRootNodeSubscriberTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace OpenOrchestra\Backoffice\Tests\EventSubscriber;
+
+use OpenOrchestra\Backoffice\EventSubscriber\CreateRootNodeSubscriber;
+use OpenOrchestra\ModelInterface\SiteEvents;
+use Phake;
+
+/**
+ * Class CreateNodeRootSubscriberTest
+ */
+class CreateNodeRootSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    protected $objectManager;
+    protected $nodeManager;
+    protected $translator;
+    /**
+     * @var CreateRootNodeSubscriber
+     */
+    protected $subscriber;
+    protected $repositoryTemplate;
+    protected $siteEvent;
+    protected $site;
+
+    /**
+     * Set up the test
+     */
+    public function setUp()
+    {
+        $this->site = Phake::mock('OpenOrchestra\ModelInterface\Model\SiteInterface');
+        $this->siteEvent = Phake::mock('OpenOrchestra\ModelInterface\Event\SiteEvent');
+        Phake::when($this->siteEvent)->getSite()->thenReturn($this->site);
+        $this->objectManager = Phake::mock('Doctrine\Common\Persistence\ObjectManager');
+        $this->nodeManager = Phake::mock('OpenOrchestra\Backoffice\Manager\NodeManager');
+        $this->translator = Phake::mock('Symfony\Component\Translation\TranslatorInterface');
+        $this->repositoryTemplate = Phake::mock('OpenOrchestra\ModelInterface\Repository\TemplateRepositoryInterface');
+
+        $this->subscriber = new CreateRootNodeSubscriber(
+            $this->nodeManager,
+            $this->repositoryTemplate,
+            $this->objectManager,
+            $this->translator
+        );
+    }
+
+    /**
+     * Test event subscribed
+     */
+    public function testEventSubscribed()
+    {
+        $this->assertArrayHasKey(SiteEvents::SITE_CREATE, $this->subscriber->getSubscribedEvents());
+    }
+
+    /**
+     * @param string $fakeTemplateId
+     * @param int    $countCreateRootNode
+     *
+     * @dataProvider provideTemplateIdAndCountCreateRootNode
+     */
+    public function testCreateRootNode($fakeTemplateId, $countCreateRootNode)
+    {
+        $template = Phake::mock('OpenOrchestra\ModelInterface\Model\TemplateInterface');
+        Phake::when($this->repositoryTemplate)->findOneByTemplateId(Phake::anyParameters())->thenReturn($template);
+        Phake::when($this->siteEvent)->getTemplateIdNodeHome()->thenReturn($fakeTemplateId);
+
+        $this->subscriber->createRootNode($this->siteEvent);
+
+        Phake::verify($this->nodeManager, Phake::times($countCreateRootNode))->createRootNode(Phake::anyParameters());
+        Phake::verify($this->objectManager, Phake::times($countCreateRootNode))->persist(Phake::anyParameters());
+        Phake::verify($this->objectManager, Phake::times($countCreateRootNode))->flush();
+    }
+
+    /**
+     * @return array
+     */
+    public function provideTemplateIdAndCountCreateRootNode()
+    {
+        return array(
+            "with template id" => array('fakeTemplateid', 1),
+            "no template id "  => array(null, 0)
+        );
+    }
+}

--- a/Backoffice/Tests/EventSubscriber/CreateRootNodeSubscriberTest.php
+++ b/Backoffice/Tests/EventSubscriber/CreateRootNodeSubscriberTest.php
@@ -61,7 +61,7 @@ class CreateNodeRootSubscriberTest extends \PHPUnit_Framework_TestCase
     {
         $template = Phake::mock('OpenOrchestra\ModelInterface\Model\TemplateInterface');
         Phake::when($this->repositoryTemplate)->findOneByTemplateId(Phake::anyParameters())->thenReturn($template);
-        Phake::when($this->siteEvent)->getTemplateIdNodeHome()->thenReturn($fakeTemplateId);
+        Phake::when($this->siteEvent)->getRootNodeTemplateId()->thenReturn($fakeTemplateId);
 
         $this->subscriber->createRootNode($this->siteEvent);
 

--- a/Backoffice/Tests/EventSubscriber/NodeTemplateSelectionSubscriberTest.php
+++ b/Backoffice/Tests/EventSubscriber/NodeTemplateSelectionSubscriberTest.php
@@ -169,7 +169,7 @@ class NodeTemplateSelectionSubscriberTest extends AbstractBaseTestCase
 
         $this->subscriber->preSubmit($this->event);
 
-        Phake::verify($templateChoiceContainer, Phake::times((null === $template)? 0: 1))->addArea(Phake::anyParameters());
+        Phake::verify($this->nodeManager, Phake::times((null === $template)? 0: 1))->hydrateAreaFromTemplate(Phake::anyParameters());
     }
 
     /**

--- a/Backoffice/Tests/EventSubscriber/WebSiteNodeTemplateSubscriberTest.php
+++ b/Backoffice/Tests/EventSubscriber/WebSiteNodeTemplateSubscriberTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace OpenOrchestra\Backoffice\Tests\EventSubscriber;
+
+use OpenOrchestra\Backoffice\EventSubscriber\WebSiteNodeTemplateSubscriber;
+use Phake;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * Class WebSiteNodeTemplateSubscriberTest
+ */
+class WebSiteNodeTemplateSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    protected $templateRepository;
+    /** @var WebSiteNodeTemplateSubscriber  */
+    protected $subscriber;
+    protected $data;
+    protected $event;
+    protected $form;
+    protected $templateChoices = array();
+
+    /**
+     * Set up the test
+     */
+    public function setUp()
+    {
+        $this->form = Phake::mock('Symfony\Component\Form\Form');
+        $this->data = Phake::mock('OpenOrchestra\ModelInterface\Model\SiteInterface');
+        $this->event = Phake::mock('Symfony\Component\Form\FormEvent');
+        Phake::when($this->event)->getForm()->thenReturn($this->form);
+        Phake::when($this->event)->getData()->thenReturn($this->data);
+
+        $this->templateRepository = Phake::mock('OpenOrchestra\ModelBundle\Repository\TemplateRepository');
+        Phake::when($this->templateRepository)->findByDeleted(false)->thenReturn($this->templateChoices);
+
+        $this->subscriber = new WebSiteNodeTemplateSubscriber($this->templateRepository);
+    }
+
+    /**
+     * @param string $siteId
+     * @param int    $countAddForm
+     *
+     * @dataProvider provideSiteIdAndCountAddForm
+     */
+    public function testOnPreSetData($siteId, $countAddForm)
+    {
+        Phake::when($this->data)->getSiteId()->thenReturn($siteId);
+        $this->subscriber->onPreSetData($this->event);
+        Phake::verify($this->form, Phake::times($countAddForm))->add('templateId', 'choice', array(
+            'choices' => $this->templateChoices,
+            'required' => true,
+            'mapped' => false,
+            'label' => 'open_orchestra_backoffice.form.website.template_node_root.label',
+            'attr'  => array(
+                'help_text' => 'open_orchestra_backoffice.form.website.template_node_root.helper',
+            )
+        ));
+    }
+
+    /**
+     * @return array
+     */
+    public function provideSiteIdAndCountAddForm()
+    {
+        return array(
+            "with site id in data" => array('fakeSiteId', 0),
+            "no site id in data" => array(null, 1)
+        );
+    }
+
+    /**
+     * Test subscribed events
+     */
+    public function testEventSubscribed()
+    {
+        $this->assertArrayHasKey(FormEvents::PRE_SET_DATA, $this->subscriber->getSubscribedEvents());
+    }
+}

--- a/Backoffice/Tests/Form/Type/SiteTypeTest.php
+++ b/Backoffice/Tests/Form/Type/SiteTypeTest.php
@@ -25,9 +25,10 @@ class SiteTypeTest extends AbstractBaseTestCase
     public function setUp()
     {
         $this->translator = Phake::mock('Symfony\Component\Translation\TranslatorInterface');
+        $repositoryTemplate = Phake::mock('OpenOrchestra\ModelInterface\Repository\TemplateRepositoryInterface');
         Phake::when($this->translator)->trans(Phake::anyParameters())->thenReturn('foo');
 
-        $this->form = new SiteType($this->siteClass, $this->translator);
+        $this->form = new SiteType($this->siteClass, $this->translator, $repositoryTemplate);
     }
 
     /**
@@ -59,7 +60,7 @@ class SiteTypeTest extends AbstractBaseTestCase
 
         Phake::verify($builder, Phake::times(12))->add(Phake::anyParameters());
         Phake::verify($this->translator, Phake::times(3))->trans(Phake::anyParameters());
-        Phake::verify($builder, Phake::times(1))->addEventSubscriber(Phake::anyParameters());
+        Phake::verify($builder, Phake::times(2))->addEventSubscriber(Phake::anyParameters());
     }
 
     /**

--- a/Backoffice/Tests/Manager/NodeManagerTest.php
+++ b/Backoffice/Tests/Manager/NodeManagerTest.php
@@ -272,22 +272,24 @@ class NodeManagerTest extends AbstractBaseTestCase
     }
 
     /**
-     * Test initializeNewNode
+     * Test initializeNode
      *
+     * @param string               $language
+     * @param string               $siteId
      * @param NodeInterface|null   $parentNode
      * @param StatusInterface|null $status
      *
      * @dataProvider provideParentNode
      */
-    public function testInitializeNewNode(NodeInterface $parentNode = null, $status = null)
+    public function testInitializeNode($language, $siteId, NodeInterface $parentNode = null, $status = null)
     {
         Phake::when($this->nodeRepository)->findVersion(Phake::anyParameters())->thenReturn($parentNode);
         Phake::when($this->statusRepository)->findOneByEditable()->thenReturn($status);
-        $node = $this->manager->initializeNewNode('fakeParentId');
+        $node = $this->manager->initializeNode('fakeParentId', $language, $siteId);
 
         $this->assertInstanceOf($this->nodeClass, $node);
-        $this->assertEquals('fakeSiteId', $node->getSiteId());
-        $this->assertEquals('fakeLanguage', $node->getLanguage());
+        $this->assertEquals($siteId, $node->getSiteId());
+        $this->assertEquals($language, $node->getLanguage());
         $this->assertEquals(NodeInterface::THEME_DEFAULT, $node->getTheme());
         $this->assertTrue($node->hasDefaultSiteTheme());
         $this->assertEquals('fake keyword', $node->getMetaKeywords());
@@ -319,9 +321,9 @@ class NodeManagerTest extends AbstractBaseTestCase
         Phake::when($status)->getFromRoles()->thenReturn(array());
 
         return array(
-            array($parentNode0, null),
-            array($parentNode1, EmbedStatus::createFromStatus($status)),
-            array(null, EmbedStatus::createFromStatus($status)),
+            array('fake_language', 'fake_site_Id', $parentNode0, null),
+            array('fake_language2', 'fake_site_Id2', $parentNode1, EmbedStatus::createFromStatus($status)),
+            array('fake_language3', 'fake_site_Id3', null, EmbedStatus::createFromStatus($status)),
         );
     }
 

--- a/Backoffice/Tests/Manager/SiteManagerTest.php
+++ b/Backoffice/Tests/Manager/SiteManagerTest.php
@@ -28,9 +28,9 @@ class SiteManagerTest extends AbstractBaseTestCase
     }
 
     /**
-     * Test initializeNewNode
+     * Test initializeNewSite
      */
-    public function testInitializeNewNode()
+    public function testInitializeNewSite()
     {
         $site = $this->manager->initializeNewSite();
 

--- a/BackofficeBundle/Controller/NodeController.php
+++ b/BackofficeBundle/Controller/NodeController.php
@@ -2,7 +2,6 @@
 
 namespace OpenOrchestra\BackofficeBundle\Controller;
 
-use OpenOrchestra\Backoffice\NavigationPanel\Strategies\AdministrationPanelStrategy;
 use OpenOrchestra\Backoffice\NavigationPanel\Strategies\GeneralNodesPanelStrategy;
 use OpenOrchestra\Backoffice\NavigationPanel\Strategies\TreeNodesPanelStrategy;
 use OpenOrchestra\ModelInterface\Event\NodeEvent;
@@ -59,14 +58,13 @@ class NodeController extends AbstractAdminController
     {
         $parentNode = $this->get('open_orchestra_model.repository.node')->findOneByNodeId($parentId);
 
-        if (null !== $parentNode) {
-            $creationRole = $parentNode->getNodeType() === NodeInterface::TYPE_TRANSVERSE? GeneralNodesPanelStrategy::ROLE_ACCESS_TREE_GENERAL_NODE:TreeNodesPanelStrategy::ROLE_ACCESS_CREATE_NODE;
-            $this->denyAccessUnlessGranted($creationRole, $parentNode);
-        } else {
-            $this->denyAccessUnlessGranted(AdministrationPanelStrategy::ROLE_ACCESS_CREATE_SITE);
-        }
+        $creationRole = $parentNode->getNodeType() === NodeInterface::TYPE_TRANSVERSE? GeneralNodesPanelStrategy::ROLE_ACCESS_TREE_GENERAL_NODE:TreeNodesPanelStrategy::ROLE_ACCESS_CREATE_NODE;
+        $this->denyAccessUnlessGranted($creationRole, $parentNode);
 
-        $node = $this->get('open_orchestra_backoffice.manager.node')->initializeNewNode($parentId);
+        $contextManager = $this->get('open_orchestra_backoffice.context_manager');
+        $language = $contextManager->getCurrentSiteDefaultLanguage();
+        $siteId = $contextManager->getCurrentSiteId();
+        $node = $this->get('open_orchestra_backoffice.manager.node')->initializeNode($parentId, $language, $siteId);
 
         $url = $this->generateUrl('open_orchestra_backoffice_node_new', array('parentId' => $parentId));
         $message = $this->get('translator')->trans('open_orchestra_backoffice.form.node.success');

--- a/BackofficeBundle/Controller/SiteController.php
+++ b/BackofficeBundle/Controller/SiteController.php
@@ -73,7 +73,8 @@ class SiteController extends AbstractAdminController
         $message = $this->get('translator')->trans('open_orchestra_backoffice.form.website.creation');
 
         if ($this->handleForm($form, $message, $site)) {
-            $this->dispatchEvent(SiteEvents::SITE_CREATE, new SiteEvent($site));
+            $templateId = $form->get('templateId')->getData();
+            $this->dispatchEvent(SiteEvents::SITE_CREATE, new SiteEvent($site, null, $templateId));
             $response = new Response('', Response::HTTP_CREATED, array('Content-type' => 'text/html; charset=utf-8'));
 
             return $this->render('BraincraftedBootstrapBundle::flash.html.twig', array(), $response);

--- a/BackofficeBundle/Resources/config/form.yml
+++ b/BackofficeBundle/Resources/config/form.yml
@@ -155,6 +155,7 @@ services:
         arguments:
             - %open_orchestra_model.document.site.class%
             - @translator
+            - @open_orchestra_model.repository.template
         tags:
             - { name: form.type, alias: oo_site }
     open_orchestra_backoffice.type.site_alias:

--- a/BackofficeBundle/Resources/config/subscriber.yml
+++ b/BackofficeBundle/Resources/config/subscriber.yml
@@ -10,6 +10,7 @@ parameters:
     open_orchestra_backoffice.subscriber.update_route_document.class: OpenOrchestra\Backoffice\EventSubscriber\UpdateRouteDocumentSubscriber
     open_orchestra_backoffice.subscriber.add_transverse_block.class: OpenOrchestra\Backoffice\EventSubscriber\AddTransverseBlockSubscriber
     open_orchestra_backoffice.subscriber.create_transverse_node.class: OpenOrchestra\Backoffice\EventSubscriber\CreateTransverseNodeSubscriber
+    open_orchestra_backoffice.subscriber.create_root_node.class: OpenOrchestra\Backoffice\EventSubscriber\CreateRootNodeSubscriber
 
 services:
     open_orchestra_backoffice.subscriber.update_child_node_path:
@@ -90,5 +91,14 @@ services:
             - @open_orchestra_model.repository.node
             - @open_orchestra_backoffice.manager.node
             - @object_manager
+        tags:
+            - { name: kernel.event_subscriber }
+    open_orchestra_backoffice.subscriber.create_root_node:
+        class: %open_orchestra_backoffice.subscriber.create_root_node.class%
+        arguments:
+            - @open_orchestra_backoffice.manager.node
+            - @open_orchestra_model.repository.template
+            - @object_manager
+            - @translator
         tags:
             - { name: kernel.event_subscriber }

--- a/BackofficeBundle/Resources/translations/messages.en.yml
+++ b/BackofficeBundle/Resources/translations/messages.en.yml
@@ -119,7 +119,7 @@ open_orchestra_backoffice:
             robots_txt: Informations contained in the robots.txt file
             template_node_root:
                 label: Homepage template
-                helper: Template used to create homepage of your site.
+                helper: Template used to create the homepage of your site.
             changefreq:
                 title: Indicative periodicity of change (for the sitemap)
                 helper: Indicative periodicity of change (for the sitemap)

--- a/BackofficeBundle/Resources/translations/messages.en.yml
+++ b/BackofficeBundle/Resources/translations/messages.en.yml
@@ -117,6 +117,9 @@ open_orchestra_backoffice:
             meta_index: Meta index
             meta_follow: Meta follow
             robots_txt: Informations contained in the robots.txt file
+            template_node_root:
+                label: Homepage template
+                helper: Template used to create homepage of your site.
             changefreq:
                 title: Indicative periodicity of change (for the sitemap)
                 helper: Indicative periodicity of change (for the sitemap)
@@ -506,6 +509,7 @@ open_orchestra_backoffice:
             at: Last update
             by: by
     node:
+        root_name: Homepage
         version:
             create: New version
             display: version

--- a/BackofficeBundle/Resources/translations/messages.fr.yml
+++ b/BackofficeBundle/Resources/translations/messages.fr.yml
@@ -117,6 +117,9 @@ open_orchestra_backoffice:
             index: Meta index
             follow: Meta follow
             robots_txt: Informations contenues dans le fichier robots.txt
+            template_node_root:
+                label: Temlate de la page d'accueil
+                helper: Template utilisé pour la génération de la page d'accueil de votre site.
             changefreq:
                 title: Fréquence de modification indicative (pour le sitemap)
                 helper: Fréquence de modification indicative (pour le sitemap)
@@ -506,6 +509,7 @@ open_orchestra_backoffice:
             at: Dernière mise à jour
             by: par
     node:
+        root_name: Page d'accueil
         version:
             create: Nouvelle version
             display: version

--- a/BackofficeBundle/Resources/translations/messages.fr.yml
+++ b/BackofficeBundle/Resources/translations/messages.fr.yml
@@ -118,8 +118,8 @@ open_orchestra_backoffice:
             follow: Meta follow
             robots_txt: Informations contenues dans le fichier robots.txt
             template_node_root:
-                label: Temlate de la page d'accueil
-                helper: Template utilisé pour la génération de la page d'accueil de votre site.
+                label: Gabarit de la page d'accueil
+                helper: Gabarit utilisé pour la génération de la page d'accueil de votre site.
             changefreq:
                 title: Fréquence de modification indicative (pour le sitemap)
                 helper: Fréquence de modification indicative (pour le sitemap)


### PR DESCRIPTION
[OO-DEPRECATED] ``initializeNewNode``  is deprecated and replace by ``initializeNode`` in class ``OpenOrchestra\Backoffice\Manager\NodeManager``. this method will be removed in 1.2.0
[OO-FEATURE] When a website is created, an homepage for this site is also created.


https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1518
https://github.com/open-orchestra/open-orchestra-model-interface/pull/169