### PR TITLE
Block menu cache

### DIFF
--- a/Backoffice/EventSubscriber/BlockMenuCacheSubscriber.php
+++ b/Backoffice/EventSubscriber/BlockMenuCacheSubscriber.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace OpenOrchestra\Backoffice\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use OpenOrchestra\ModelInterface\NodeEvents;
+use OpenOrchestra\ModelInterface\Event\NodeEvent;
+use OpenOrchestra\DisplayBundle\Manager\CacheableManager;
+use OpenOrchestra\BaseBundle\Manager\TagManager;
+
+/**
+ * Class BlockMenuCacheSubscriber
+ *
+ */
+class BlockMenuCacheSubscriber implements EventSubscriberInterface
+{
+    protected $cacheableManager;
+    protected $tagManager;
+
+    /**
+     * @param CacheableManager $cacheableManager
+     * @param TagManager       $tagManager
+     */
+    public function __construct(CacheableManager $cacheableManager, TagManager $tagManager)
+    {
+        $this->cacheableManager = $cacheableManager;
+        $this->tagManager = $tagManager;
+    }
+
+    /**
+     * Triggered when a node status changes
+     *
+     * @param NodeEvent $event
+     */
+    public function invalidateNodeTag(NodeEvent $event)
+    {
+        $node = $event->getNode();
+        $siteId = $node->getSiteId();
+        $this->cacheableManager->invalidateTags(
+            array(
+                $this->tagManager->formatMenuTag($siteId)
+            )
+        );
+    }
+
+    /**
+     * @return array The event names to listen to
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            NodeEvents::PATH_UPDATED => 'invalidateNodeTag'
+        );
+    }
+}

--- a/Backoffice/EventSubscriber/BlockMenuCacheSubscriber.php
+++ b/Backoffice/EventSubscriber/BlockMenuCacheSubscriber.php
@@ -49,7 +49,10 @@ class BlockMenuCacheSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            NodeEvents::PATH_UPDATED => 'invalidateNodeTag'
+            NodeEvents::PATH_UPDATED => 'invalidateNodeTag',
+            NodeEvents::NODE_DELETE => 'invalidateNodeTag',
+            NodeEvents::NODE_CHANGE_STATUS => 'invalidateNodeTag',
+            NodeEvents::NODE_RESTORE => 'invalidateNodeTag',
         );
     }
 }

--- a/Backoffice/Tests/EventSubscriber/BlockMenuCacheSubscriberTest.php
+++ b/Backoffice/Tests/EventSubscriber/BlockMenuCacheSubscriberTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace OpenOrchestra\Backoffice\Tests\EventSubscriber;
+
+use OpenOrchestra\Backoffice\EventSubscriber\BlockMenuCacheSubscriber;
+use OpenOrchestra\BaseBundle\Tests\AbstractTest\AbstractBaseTestCase;
+use Phake;
+use OpenOrchestra\ModelInterface\NodeEvents;
+
+/**
+ * Class BlockMenuCacheSubscriberTest
+ */
+class BlockMenuCacheSubscriberTest extends AbstractBaseTestCase
+{
+    protected $cacheableManager;
+    protected $tagManager;
+    protected $nodeEvent;
+    protected $node;
+    protected $nodeId = 'nodeId';
+    protected $menuTag = 'menu-fake';
+    protected $subscriber;
+
+    /**
+     * Set up the test
+     */
+    public function setUp()
+    {
+        $this->cacheableManager = Phake::mock('OpenOrchestra\DisplayBundle\Manager\CacheableManager');
+        $this->tagManager = Phake::mock('OpenOrchestra\BaseBundle\Manager\TagManager');
+        Phake::when($this->tagManager)->formatMenuTag(Phake::anyParameters())->thenReturn($this->menuTag);
+
+        $this->node = Phake::mock('OpenOrchestra\ModelBundle\Document\Node');
+        Phake::when($this->node)->getNodeId()->thenReturn($this->nodeId);
+
+        $this->nodeEvent = Phake::mock('OpenOrchestra\ModelInterface\Event\NodeEvent');
+        Phake::when($this->nodeEvent)->getNode()->thenReturn($this->node);
+
+        $this->subscriber = new BlockMenuCacheSubscriber($this->cacheableManager, $this->tagManager);
+    }
+
+    /**
+     * Test instance
+     */
+    public function testInstance()
+    {
+        $this->assertInstanceOf('Symfony\Component\EventDispatcher\EventSubscriberInterface', $this->subscriber);
+    }
+
+    /**
+     * @param string $eventName
+     *
+     * @dataProvider provideSubscribedEvent
+     */
+    public function testEventSubscribed($eventName)
+    {
+        $this->assertArrayHasKey($eventName, $this->subscriber->getSubscribedEvents());
+    }
+
+    /**
+     * @return array
+     */
+    public function provideSubscribedEvent()
+    {
+        return array(
+            array(NodeEvents::PATH_UPDATED),
+            array(NodeEvents::NODE_DELETE),
+            array(NodeEvents::NODE_CHANGE_STATUS),
+        );
+    }
+
+    /**
+     * Test nodeChangeStatus
+     */
+    public function testInvalidateNodeTag()
+    {
+        $this->subscriber->invalidateNodeTag($this->nodeEvent);
+
+        Phake::verify($this->cacheableManager)->invalidateTags(array($this->menuTag));
+    }
+}

--- a/BackofficeBundle/Resources/config/form.yml
+++ b/BackofficeBundle/Resources/config/form.yml
@@ -369,6 +369,7 @@ services:
         arguments:
             - @open_orchestra_backoffice.collector.front_role
             - oo_front_role_choice
+            - {}
         tags:
             - { name: form.type, alias: oo_front_role_choice }
     open_orchestra_backoffice.type.api_client:

--- a/BackofficeBundle/Resources/config/subscriber.yml
+++ b/BackofficeBundle/Resources/config/subscriber.yml
@@ -3,6 +3,7 @@ parameters:
     open_orchestra_backoffice.subscriber.update_node_redirection.class: OpenOrchestra\Backoffice\EventSubscriber\UpdateNodeRedirectionSubscriber
     open_orchestra_backoffice.subscriber.update_redirection_node.class: OpenOrchestra\Backoffice\EventSubscriber\UpdateRedirectionNodeSubscriber
     open_orchestra_backoffice.subscriber.flush_node_clache.class: OpenOrchestra\Backoffice\EventSubscriber\FlushNodeCacheSubscriber
+    open_orchestra_backoffice.subscriber.block_menu_cache.class: OpenOrchestra\Backoffice\EventSubscriber\BlockMenuCacheSubscriber
     open_orchestra_backoffice.subscriber.change_content_status.class: OpenOrchestra\Backoffice\EventSubscriber\ChangeContentStatusSubscriber
     open_orchestra_backoffice.subscriber.content_type.class: OpenOrchestra\Backoffice\EventSubscriber\ContentTypeSubscriber
     open_orchestra_backoffice.subscriber.update_status.class: OpenOrchestra\Backoffice\EventSubscriber\UpdateStatusSubscriber
@@ -41,6 +42,13 @@ services:
             - { name: kernel.event_subscriber }
     open_orchestra_backoffice.subscriber.flush_node_clache:
         class: %open_orchestra_backoffice.subscriber.flush_node_clache.class%
+        arguments:
+            - @open_orchestra_display.manager.cacheable
+            - @open_orchestra_base.manager.tag
+        tags:
+            - { name: kernel.event_subscriber }
+    open_orchestra_backoffice.subscriber.block_menu_cache:
+        class: %open_orchestra_backoffice.subscriber.block_menu_cache.class%
         arguments:
             - @open_orchestra_display.manager.cacheable
             - @open_orchestra_base.manager.tag


### PR DESCRIPTION
[OO-FEATURE] Block menu are invalidate when a node is removed, moved, restore and the status of a node changes .

https://github.com/open-orchestra/open-orchestra-display-bundle/pull/205
https://github.com/open-orchestra/open-orchestra-base-bundle/pull/75
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1531