### PR TITLE
invalidate tag when update content and content type

### DIFF
--- a/Backoffice/EventSubscriber/ChangeContentStatusSubscriber.php
+++ b/Backoffice/EventSubscriber/ChangeContentStatusSubscriber.php
@@ -38,7 +38,6 @@ class ChangeContentStatusSubscriber implements EventSubscriberInterface
     public function contentChangeStatus(ContentEvent $event)
     {
         $content = $event->getContent();
-        dump($event->getPreviousStatus());
 
         $this->cacheableManager->invalidateTags(
             array(

--- a/Backoffice/EventSubscriber/ChangeContentStatusSubscriber.php
+++ b/Backoffice/EventSubscriber/ChangeContentStatusSubscriber.php
@@ -8,8 +8,12 @@ use OpenOrchestra\ModelInterface\Event\ContentEvent;
 use OpenOrchestra\DisplayBundle\Manager\CacheableManager;
 use OpenOrchestra\BaseBundle\Manager\TagManager;
 
+@trigger_error('The '.__NAMESPACE__.'\ChangeContentStatusSubscriber class is deprecated since version 1.1.0 and will be removed in 1.2.0, it is replace by ContentUpdateCacheSubscriber', E_USER_DEPRECATED);
+
 /**
  * Class ChangeContentStatusSubscriber
+ *
+ * @deprecated ChangeContentStatusSubscriber is deprecated in 1.1.0 and will be removed in 1.2.0, it is replace by ContentUpdateCacheSubscriber
  */
 class ChangeContentStatusSubscriber implements EventSubscriberInterface
 {
@@ -34,6 +38,7 @@ class ChangeContentStatusSubscriber implements EventSubscriberInterface
     public function contentChangeStatus(ContentEvent $event)
     {
         $content = $event->getContent();
+        dump($event->getPreviousStatus());
 
         $this->cacheableManager->invalidateTags(
             array(

--- a/Backoffice/EventSubscriber/ContentTypeUpdateCacheSubscriber.php
+++ b/Backoffice/EventSubscriber/ContentTypeUpdateCacheSubscriber.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace OpenOrchestra\Backoffice\EventSubscriber;
+
+use OpenOrchestra\ModelInterface\ContentTypeEvents;
+use OpenOrchestra\ModelInterface\Event\ContentTypeEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use OpenOrchestra\DisplayBundle\Manager\CacheableManager;
+use OpenOrchestra\BaseBundle\Manager\TagManager;
+
+/**
+ * Class ContentTypeUpdateCacheSubscriber
+ */
+class ContentTypeUpdateCacheSubscriber implements EventSubscriberInterface
+{
+    protected $cacheableManager;
+    protected $tagManager;
+
+    /**
+     * @param CacheableManager $cacheableManager
+     * @param TagManager       $tagManager
+     */
+    public function __construct(CacheableManager $cacheableManager, TagManager $tagManager)
+    {
+        $this->cacheableManager = $cacheableManager;
+        $this->tagManager = $tagManager;
+    }
+
+    /**
+     * @param ContentTypeEvent $event
+     */
+    public function invalidateTagContentType(ContentTypeEvent $event)
+    {
+        $contentType = $event->getContentType();
+        $this->cacheableManager->invalidateTags(
+            array(
+                $this->tagManager->formatContentTypeTag($contentType->getContentTypeId())
+            )
+        );
+    }
+
+    /**
+     * @return array The event names to listen to
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            ContentTypeEvents::CONTENT_TYPE_UPDATE => 'invalidateTagContentType',
+            ContentTypeEvents::CONTENT_TYPE_DELETE => 'invalidateTagContentType',
+        );
+    }
+}

--- a/Backoffice/EventSubscriber/ContentUpdateCacheSubscriber.php
+++ b/Backoffice/EventSubscriber/ContentUpdateCacheSubscriber.php
@@ -43,7 +43,7 @@ class ContentUpdateCacheSubscriber implements EventSubscriberInterface
    /**
      * @param ContentEvent $event
      */
-    public function invalidateCacheOnDeleteContentPublished(ContentEvent $event)
+    public function invalidateCacheOnDeletePublishedContent(ContentEvent $event)
     {
         $content = $event->getContent();
         $status = $content->getStatus();
@@ -74,7 +74,7 @@ class ContentUpdateCacheSubscriber implements EventSubscriberInterface
     {
         return array(
             ContentEvents::CONTENT_CHANGE_STATUS => 'invalidateCacheOnStatusChanged',
-            ContentEvents::CONTENT_DELETE => 'invalidateCacheOnDeleteContentPublished'
+            ContentEvents::CONTENT_DELETE => 'invalidateCacheOnDeletePublishedContent'
         );
     }
 }

--- a/Backoffice/EventSubscriber/ContentUpdateCacheSubscriber.php
+++ b/Backoffice/EventSubscriber/ContentUpdateCacheSubscriber.php
@@ -31,7 +31,7 @@ class ContentUpdateCacheSubscriber implements EventSubscriberInterface
     /**
      * @param ContentEvent $event
      */
-    public function contentChangeStatus(ContentEvent $event)
+    public function invalidateCacheOnStatusChanged(ContentEvent $event)
     {
         $content = $event->getContent();
         $previousStatus = $event->getPreviousStatus();
@@ -43,7 +43,7 @@ class ContentUpdateCacheSubscriber implements EventSubscriberInterface
    /**
      * @param ContentEvent $event
      */
-    public function deleteContentPublished(ContentEvent $event)
+    public function invalidateCacheOnDeleteContentPublished(ContentEvent $event)
     {
         $content = $event->getContent();
         $status = $content->getStatus();
@@ -73,8 +73,8 @@ class ContentUpdateCacheSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            ContentEvents::CONTENT_CHANGE_STATUS => 'contentChangeStatus',
-            ContentEvents::CONTENT_DELETE => 'deleteContentPublished'
+            ContentEvents::CONTENT_CHANGE_STATUS => 'invalidateCacheOnStatusChanged',
+            ContentEvents::CONTENT_DELETE => 'invalidateCacheOnDeleteContentPublished'
         );
     }
 }

--- a/Backoffice/EventSubscriber/ContentUpdateCacheSubscriber.php
+++ b/Backoffice/EventSubscriber/ContentUpdateCacheSubscriber.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace OpenOrchestra\Backoffice\EventSubscriber;
+
+use OpenOrchestra\ModelInterface\Model\ContentInterface;
+use OpenOrchestra\ModelInterface\Model\StatusInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use OpenOrchestra\ModelInterface\ContentEvents;
+use OpenOrchestra\ModelInterface\Event\ContentEvent;
+use OpenOrchestra\DisplayBundle\Manager\CacheableManager;
+use OpenOrchestra\BaseBundle\Manager\TagManager;
+
+/**
+ * Class ContentUpdateCacheSubscriber
+ */
+class ContentUpdateCacheSubscriber implements EventSubscriberInterface
+{
+    protected $cacheableManager;
+    protected $tagManager;
+
+    /**
+     * @param CacheableManager $cacheableManager
+     * @param TagManager       $tagManager
+     */
+    public function __construct(CacheableManager $cacheableManager, TagManager $tagManager)
+    {
+        $this->cacheableManager = $cacheableManager;
+        $this->tagManager = $tagManager;
+    }
+
+    /**
+     * @param ContentEvent $event
+     */
+    public function contentChangeStatus(ContentEvent $event)
+    {
+        $content = $event->getContent();
+        $previousStatus = $event->getPreviousStatus();
+        if ($previousStatus instanceof StatusInterface) {
+            $this->invalidateTagsContent($content, $previousStatus);
+        }
+    }
+
+   /**
+     * @param ContentEvent $event
+     */
+    public function deleteContentPublished(ContentEvent $event)
+    {
+        $content = $event->getContent();
+        $status = $content->getStatus();
+        if ($status instanceof StatusInterface) {
+            $this->invalidateTagsContent($content, $status);
+        }
+    }
+
+    /**
+     * @param ContentInterface $content
+     * @param StatusInterface  $status
+     */
+    protected function invalidateTagsContent(ContentInterface $content, StatusInterface $status)
+    {
+        if ($status->isPublished()) {
+            $this->cacheableManager->invalidateTags(
+                array(
+                    $this->tagManager->formatContentIdTag($content->getContentId())
+                )
+            );
+        }
+    }
+
+    /**
+     * @return array The event names to listen to
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            ContentEvents::CONTENT_CHANGE_STATUS => 'contentChangeStatus',
+            ContentEvents::CONTENT_DELETE => 'deleteContentPublished'
+        );
+    }
+}

--- a/Backoffice/Tests/EventSubscriber/ContentTypeUpdateCacheSubscriberTest.php
+++ b/Backoffice/Tests/EventSubscriber/ContentTypeUpdateCacheSubscriberTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace OpenOrchestra\Backoffice\Tests\EventSubscriber;
+
+use OpenOrchestra\Backoffice\EventSubscriber\ContentTypeUpdateCacheSubscriber;
+use OpenOrchestra\BaseBundle\Tests\AbstractTest\AbstractBaseTestCase;
+use OpenOrchestra\ModelInterface\ContentTypeEvents;
+use Phake;
+
+/**
+ * Class ContentTypeUpdateCacheSubscriberTest
+ */
+class ContentTypeUpdateCacheSubscriberTest extends AbstractBaseTestCase
+{
+    protected $cacheableManager;
+    protected $tagManager;
+    protected $contentTypeEvent;
+    protected $contentType;
+    protected $contentTypeId = 'contentTypeId';
+    protected $contentTypeIdTag = 'contentTypeIdTag';
+    /**
+     * @var ContentTypeUpdateCacheSubscriber
+     */
+    protected $subscriber;
+
+    /**
+     * Set up the test
+     */
+    public function setUp()
+    {
+        $this->cacheableManager = Phake::mock('OpenOrchestra\DisplayBundle\Manager\CacheableManager');
+        $this->tagManager = Phake::mock('OpenOrchestra\BaseBundle\Manager\TagManager');
+        Phake::when($this->tagManager)->formatContentTypeTag(Phake::anyParameters())->thenReturn($this->contentTypeIdTag);
+
+        $this->contentType = Phake::mock('OpenOrchestra\ModelBundle\Document\ContentType');
+        Phake::when($this->contentType)->getContentTypeId()->thenReturn($this->contentTypeId);
+
+        $this->contentTypeEvent = Phake::mock('OpenOrchestra\ModelInterface\Event\ContentTypeEvent');
+        Phake::when($this->contentTypeEvent)->getContentType()->thenReturn($this->contentType);
+
+        $this->subscriber = new ContentTypeUpdateCacheSubscriber($this->cacheableManager, $this->tagManager);
+    }
+
+    /**
+     * Test instance
+     */
+    public function testInstance()
+    {
+        $this->assertInstanceOf('Symfony\Component\EventDispatcher\EventSubscriberInterface', $this->subscriber);
+    }
+
+    /**
+     * @param string $eventName
+     *
+     * @dataProvider provideSubscribedEvent
+     */
+    public function testEventSubscribed($eventName)
+    {
+        $this->assertArrayHasKey($eventName, $this->subscriber->getSubscribedEvents());
+    }
+
+    /**
+     * @return array
+     */
+    public function provideSubscribedEvent()
+    {
+        return array(
+            array(ContentTypeEvents::CONTENT_TYPE_UPDATE),
+            array(ContentTypeEvents::CONTENT_TYPE_DELETE),
+        );
+    }
+
+    /**
+     * Test invalidate tag content type
+     */
+    public function testInvalidateTagContentType()
+    {
+        $this->subscriber->invalidateTagContentType($this->contentTypeEvent);
+
+        Phake::verify($this->cacheableManager)->invalidateTags(array($this->contentTypeIdTag));
+    }
+}

--- a/Backoffice/Tests/EventSubscriber/ContentUpdateCacheSubscriberTest.php
+++ b/Backoffice/Tests/EventSubscriber/ContentUpdateCacheSubscriberTest.php
@@ -18,6 +18,8 @@ class ContentUpdateCacheSubscriberTest extends AbstractBaseTestCase
     protected $content;
     protected $contentId = 'contentId';
     protected $contentIdTag = 'contentIdTag';
+
+    /** @var ContentUpdateCacheSubscriber */
     protected $subscriber;
 
     /**
@@ -78,7 +80,7 @@ class ContentUpdateCacheSubscriberTest extends AbstractBaseTestCase
         $status = Phake::mock('OpenOrchestra\ModelInterface\Model\StatusInterface');
         Phake::when($status)->isPublished()->thenReturn($isPublished);
         Phake::when($this->contentEvent)->getPreviousStatus()->thenReturn($status);
-        $this->subscriber->contentChangeStatus($this->contentEvent);
+        $this->subscriber->invalidateCacheOnStatusChanged($this->contentEvent);
 
         Phake::verify($this->cacheableManager, Phake::times($countInvalidate))->invalidateTags(array($this->contentIdTag));
     }
@@ -105,7 +107,7 @@ class ContentUpdateCacheSubscriberTest extends AbstractBaseTestCase
         $status = Phake::mock('OpenOrchestra\ModelInterface\Model\StatusInterface');
         Phake::when($status)->isPublished()->thenReturn($isPublished);
         Phake::when($this->content)->getStatus()->thenReturn($status);
-        $this->subscriber->deleteContentPublished($this->contentEvent);
+        $this->subscriber->invalidateCacheOnDeleteContentPublished($this->contentEvent);
 
         Phake::verify($this->cacheableManager, Phake::times($countInvalidate))->invalidateTags(array($this->contentIdTag));
     }

--- a/Backoffice/Tests/EventSubscriber/ContentUpdateCacheSubscriberTest.php
+++ b/Backoffice/Tests/EventSubscriber/ContentUpdateCacheSubscriberTest.php
@@ -107,7 +107,7 @@ class ContentUpdateCacheSubscriberTest extends AbstractBaseTestCase
         $status = Phake::mock('OpenOrchestra\ModelInterface\Model\StatusInterface');
         Phake::when($status)->isPublished()->thenReturn($isPublished);
         Phake::when($this->content)->getStatus()->thenReturn($status);
-        $this->subscriber->invalidateCacheOnDeleteContentPublished($this->contentEvent);
+        $this->subscriber->invalidateCacheOnDeletePublishedContent($this->contentEvent);
 
         Phake::verify($this->cacheableManager, Phake::times($countInvalidate))->invalidateTags(array($this->contentIdTag));
     }

--- a/BackofficeBundle/Resources/config/subscriber.yml
+++ b/BackofficeBundle/Resources/config/subscriber.yml
@@ -5,6 +5,8 @@ parameters:
     open_orchestra_backoffice.subscriber.flush_node_clache.class: OpenOrchestra\Backoffice\EventSubscriber\FlushNodeCacheSubscriber
     open_orchestra_backoffice.subscriber.block_menu_cache.class: OpenOrchestra\Backoffice\EventSubscriber\BlockMenuCacheSubscriber
     open_orchestra_backoffice.subscriber.change_content_status.class: OpenOrchestra\Backoffice\EventSubscriber\ChangeContentStatusSubscriber
+    open_orchestra_backoffice.subscriber.content_update_cache.class: OpenOrchestra\Backoffice\EventSubscriber\ContentUpdateCacheSubscriber
+    open_orchestra_backoffice.subscriber.content_type_update_cache.class: OpenOrchestra\Backoffice\EventSubscriber\ContentTypeUpdateCacheSubscriber
     open_orchestra_backoffice.subscriber.content_type.class: OpenOrchestra\Backoffice\EventSubscriber\ContentTypeSubscriber
     open_orchestra_backoffice.subscriber.update_status.class: OpenOrchestra\Backoffice\EventSubscriber\UpdateStatusSubscriber
     open_orchestra_backoffice.subscriber.delete_node.class: OpenOrchestra\Backoffice\EventSubscriber\DeleteNodeSubscriber
@@ -54,8 +56,15 @@ services:
             - @open_orchestra_base.manager.tag
         tags:
             - { name: kernel.event_subscriber }
-    open_orchestra_backoffice.subscriber.change_content_status:
-        class: %open_orchestra_backoffice.subscriber.change_content_status.class%
+    open_orchestra_backoffice.subscriber.content_update_cache:
+        class: %open_orchestra_backoffice.subscriber.content_update_cache.class%
+        arguments:
+            - @open_orchestra_display.manager.cacheable
+            - @open_orchestra_base.manager.tag
+        tags:
+            - { name: kernel.event_subscriber }
+    open_orchestra_backoffice.subscriber.content_type_update_cache:
+        class: %open_orchestra_backoffice.subscriber.content_type_update_cache.class%
         arguments:
             - @open_orchestra_display.manager.cacheable
             - @open_orchestra_base.manager.tag


### PR DESCRIPTION
[OO-DEPRECATED] class ``OpenOrchestra\Backoffice\EventSubscriber\ChangeContentStatusSubscriber`` s deprecated in 1.1.0 and will be removed in 1.2.0, it is replace by ContentUpdateCacheSubscriber
[OO-FEATURE] When a content is deleted or his status is updated tag ``'contentId-' . $contentId`` is invalidate.
[OO-FEATURE] When a content type is deleted or updated tag ``''contentType-' . $contentType`` is invalidate.