### PR TITLE
fix cloned save button

### DIFF
--- a/BackofficeBundle/Resources/public/coffee/backboneRouter.coffee
+++ b/BackofficeBundle/Resources/public/coffee/backboneRouter.coffee
@@ -10,6 +10,7 @@ OrchestraBORouter = Backbone.Router.extend(
     jQuery ->
       ribbonFormButtonViewClass = appConfigurationView.getConfiguration('ribbon-form-button', 'createRibbonFormButton')
       OpenOrchestra.RibbonButton.ribbonFormButtonView = new ribbonFormButtonViewClass()
+      OpenOrchestra.RibbonButton.ribbonFormButtonModalView = new ribbonFormButtonViewClass()
     return
 
   showHome: ->

--- a/BackofficeBundle/Resources/views/BackOffice/Underscore/deleteButton._tpl.twig
+++ b/BackofficeBundle/Resources/views/BackOffice/Underscore/deleteButton._tpl.twig
@@ -1,13 +1,9 @@
-<button class="ajax-delete btn btn-labeled btn-danger"
+<button class="ajax-delete btn btn-danger"
     data-delete-url="<%= deleteUrl%>"
     data-confirm-text="<%= confirmText%>"
     data-confirm-title="<%= confirmTitle%>"
     <% if (typeof redirectUrl != 'undefined') { %>
     data-redirect-url="<%= redirectUrl%>"
     <% } %>>
-    <span class="btn-label">
-        <i class="glyphicon glyphicon-trash"></i>
-    </span>
-
     {{ 'open_orchestra_backoffice.form.delete'|trans }}
 </button>


### PR DESCRIPTION
If a page contains a cloned button we can not click this button after open a modal which contains a cloned button because the page loses focus. this PR fix that by using two instances: one for normal page and an other for modal page

https://github.com/open-orchestra/open-orchestra-media-admin-bundle/pull/199