### PR TITLE
 move TransformerParameterTypeException to base api bundle 1.1

### DIFF
--- a/ApiBundle/Exceptions/TransformerParameterTypeException.php
+++ b/ApiBundle/Exceptions/TransformerParameterTypeException.php
@@ -4,8 +4,12 @@ namespace OpenOrchestra\ApiBundle\Exceptions;
 
 use OpenOrchestra\BaseApi\Exceptions\ApiException;
 
+@trigger_error('The '.__NAMESPACE__.'\TransformerParameterTypeException class is deprecated since version 1.2.0 and will be removed in 1.3.0, use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException', E_USER_DEPRECATED);
+
 /**
  * Class TransformerParameterTypeException
+ *
+ * @deprecated will be removed in 1.3.0, use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException instead
  */
 class TransformerParameterTypeException extends ApiException
 {

--- a/ApiBundle/Tests/Transformer/BlockTransformerTest.php
+++ b/ApiBundle/Tests/Transformer/BlockTransformerTest.php
@@ -340,7 +340,7 @@ class BlockTransformerTest extends AbstractBaseTestCase
      */
     public function testExceptionTransform()
     {
-        $this->setExpectedException('OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException');
+        $this->setExpectedException('OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException');
         $this->blockTransformer->transform(Phake::mock('stdClass'));
     }
 }

--- a/ApiBundle/Tests/Transformer/ContentAttributeTransformerTest.php
+++ b/ApiBundle/Tests/Transformer/ContentAttributeTransformerTest.php
@@ -63,7 +63,7 @@ class ContentAttributeTransformerTest extends AbstractBaseTestCase
      */
     public function testExceptionTransform()
     {
-        $this->setExpectedException('OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException');
+        $this->setExpectedException('OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException');
         $this->transformer->transform(Phake::mock('stdClass'));
     }
 

--- a/ApiBundle/Tests/Transformer/ContentTransformerTest.php
+++ b/ApiBundle/Tests/Transformer/ContentTransformerTest.php
@@ -130,7 +130,7 @@ class ContentTransformerTest extends AbstractBaseTestCase
      */
     public function testExceptionTransform()
     {
-        $this->setExpectedException('OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException');
+        $this->setExpectedException('OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException');
         $this->contentTransformer->transform(Phake::mock('stdClass'));
     }
 

--- a/ApiBundle/Tests/Transformer/GroupTransformerTest.php
+++ b/ApiBundle/Tests/Transformer/GroupTransformerTest.php
@@ -64,7 +64,7 @@ class GroupTransformerTest extends AbstractBaseTestCase
      */
     public function testTransformWithWrongElement()
     {
-        $this->setExpectedException('OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException');
+        $this->setExpectedException('OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException');
         $this->transformer->transform(Phake::mock('stdClass'));
     }
 

--- a/ApiBundle/Tests/Transformer/ModelGroupRoleTransformerTest.php
+++ b/ApiBundle/Tests/Transformer/ModelGroupRoleTransformerTest.php
@@ -62,7 +62,7 @@ class ModelGroupRoleTransformerTest extends AbstractBaseTestCase
      */
     public function testTransformWithWrongElement()
     {
-        $this->setExpectedException('OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException');
+        $this->setExpectedException('OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException');
         $this->transformer->transform(Phake::mock('stdClass'));
     }
 

--- a/ApiBundle/Tests/Transformer/NodeTransformerTest.php
+++ b/ApiBundle/Tests/Transformer/NodeTransformerTest.php
@@ -208,7 +208,7 @@ class NodeTransformerTest extends AbstractBaseTestCase
      */
     public function testExceptionTransform()
     {
-        $this->setExpectedException('OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException');
+        $this->setExpectedException('OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException');
         $this->nodeTransformer->transform(Phake::mock('stdClass'));
     }
 

--- a/ApiBundle/Tests/Transformer/StatusTransformerTest.php
+++ b/ApiBundle/Tests/Transformer/StatusTransformerTest.php
@@ -130,7 +130,7 @@ class StatusTransformerTest extends AbstractBaseTestCase
      */
     public function testExceptionTransform()
     {
-        $this->setExpectedException('OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException');
+        $this->setExpectedException('OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException');
         $this->transformer->transform(Phake::mock('stdClass'));
     }
 

--- a/ApiBundle/Transformer/ApiClientTransformer.php
+++ b/ApiBundle/Transformer/ApiClientTransformer.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\ApiBundle\Transformer;
 
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\Backoffice\NavigationPanel\Strategies\AdministrationPanelStrategy;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;
 use OpenOrchestra\BaseApi\Transformer\AbstractSecurityCheckerAwareTransformer;

--- a/ApiBundle/Transformer/AreaTransformer.php
+++ b/ApiBundle/Transformer/AreaTransformer.php
@@ -3,7 +3,7 @@
 namespace OpenOrchestra\ApiBundle\Transformer;
 
 use OpenOrchestra\ApiBundle\Exceptions\HttpException\AreaTransformerHttpException;
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;
 use OpenOrchestra\BaseApi\Transformer\AbstractSecurityCheckerAwareTransformer;
 use OpenOrchestra\Backoffice\Manager\AreaManager;

--- a/ApiBundle/Transformer/BlockTransformer.php
+++ b/ApiBundle/Transformer/BlockTransformer.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\ApiBundle\Transformer;
 
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\Backoffice\DisplayIcon\DisplayManager;
 use OpenOrchestra\ApiBundle\Facade\BlockFacade;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;

--- a/ApiBundle/Transformer/ContentAttributeTransformer.php
+++ b/ApiBundle/Transformer/ContentAttributeTransformer.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\ApiBundle\Transformer;
 
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;
 use OpenOrchestra\BaseApi\Transformer\AbstractTransformer;
 use OpenOrchestra\ModelInterface\Model\ContentAttributeInterface;

--- a/ApiBundle/Transformer/ContentTransformer.php
+++ b/ApiBundle/Transformer/ContentTransformer.php
@@ -3,7 +3,7 @@
 namespace OpenOrchestra\ApiBundle\Transformer;
 
 use OpenOrchestra\ApiBundle\Exceptions\HttpException\StatusChangeNotGrantedHttpException;
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\Backoffice\Exception\StatusChangeNotGrantedException;
 use OpenOrchestra\Backoffice\NavigationPanel\Strategies\ContentTypeForContentPanelStrategy;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;

--- a/ApiBundle/Transformer/ContentTypeTransformer.php
+++ b/ApiBundle/Transformer/ContentTypeTransformer.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\ApiBundle\Transformer;
 
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\Backoffice\NavigationPanel\Strategies\AdministrationPanelStrategy;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;
 use OpenOrchestra\BaseApi\Transformer\AbstractSecurityCheckerAwareTransformer;

--- a/ApiBundle/Transformer/FieldTypeTransformer.php
+++ b/ApiBundle/Transformer/FieldTypeTransformer.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\ApiBundle\Transformer;
 
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;
 use OpenOrchestra\BaseApi\Transformer\AbstractTransformer;
 use OpenOrchestra\Backoffice\Manager\TranslationChoiceManager;

--- a/ApiBundle/Transformer/GroupTransformer.php
+++ b/ApiBundle/Transformer/GroupTransformer.php
@@ -9,7 +9,7 @@ use OpenOrchestra\GroupBundle\GroupFacadeEvents;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use OpenOrchestra\BaseApi\Transformer\AbstractSecurityCheckerAwareTransformer;
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\Backoffice\Model\GroupInterface;
 use OpenOrchestra\Backoffice\Manager\TranslationChoiceManager;
 

--- a/ApiBundle/Transformer/KeywordTransformer.php
+++ b/ApiBundle/Transformer/KeywordTransformer.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\ApiBundle\Transformer;
 
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\Backoffice\NavigationPanel\Strategies\AdministrationPanelStrategy;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;
 use OpenOrchestra\BaseApi\Transformer\AbstractSecurityCheckerAwareTransformer;

--- a/ApiBundle/Transformer/ModelGroupRoleTransformer.php
+++ b/ApiBundle/Transformer/ModelGroupRoleTransformer.php
@@ -3,7 +3,7 @@
 namespace OpenOrchestra\ApiBundle\Transformer;
 
 use OpenOrchestra\ApiBundle\Exceptions\HttpException\RoleNotFoundHttpException;
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\Backoffice\Collector\RoleCollectorInterface;
 use OpenOrchestra\Backoffice\Model\ModelGroupRoleInterface;
 use OpenOrchestra\Backoffice\Model\GroupInterface;

--- a/ApiBundle/Transformer/NodeCollectionTransformer.php
+++ b/ApiBundle/Transformer/NodeCollectionTransformer.php
@@ -3,7 +3,7 @@
 namespace OpenOrchestra\ApiBundle\Transformer;
 
 use Doctrine\Common\Collections\Collection;
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;
 use OpenOrchestra\BaseApi\Transformer\AbstractTransformer;
 

--- a/ApiBundle/Transformer/NodeTransformer.php
+++ b/ApiBundle/Transformer/NodeTransformer.php
@@ -3,7 +3,7 @@
 namespace OpenOrchestra\ApiBundle\Transformer;
 
 use OpenOrchestra\ApiBundle\Exceptions\HttpException\StatusChangeNotGrantedHttpException;
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\Backoffice\Exception\StatusChangeNotGrantedException;
 use OpenOrchestra\Backoffice\NavigationPanel\Strategies\TransverseNodePanelStrategy;
 use OpenOrchestra\Backoffice\NavigationPanel\Strategies\TreeNodesPanelStrategy;

--- a/ApiBundle/Transformer/RedirectionTransformer.php
+++ b/ApiBundle/Transformer/RedirectionTransformer.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\ApiBundle\Transformer;
 
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\Backoffice\NavigationPanel\Strategies\AdministrationPanelStrategy;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;
 use OpenOrchestra\BaseApi\Transformer\AbstractSecurityCheckerAwareTransformer;

--- a/ApiBundle/Transformer/RoleStringTransformer.php
+++ b/ApiBundle/Transformer/RoleStringTransformer.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\ApiBundle\Transformer;
 
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;
 use OpenOrchestra\BaseApi\Transformer\AbstractTransformer;
 

--- a/ApiBundle/Transformer/RoleTransformer.php
+++ b/ApiBundle/Transformer/RoleTransformer.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\ApiBundle\Transformer;
 
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\Backoffice\Manager\TranslationChoiceManager;
 use OpenOrchestra\Backoffice\NavigationPanel\Strategies\AdministrationPanelStrategy;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;

--- a/ApiBundle/Transformer/SiteTransformer.php
+++ b/ApiBundle/Transformer/SiteTransformer.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\ApiBundle\Transformer;
 
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\Backoffice\NavigationPanel\Strategies\AdministrationPanelStrategy;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;
 use OpenOrchestra\BaseApi\Transformer\AbstractSecurityCheckerAwareTransformer;

--- a/ApiBundle/Transformer/StatusTransformer.php
+++ b/ApiBundle/Transformer/StatusTransformer.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\ApiBundle\Transformer;
 
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\Backoffice\NavigationPanel\Strategies\AdministrationPanelStrategy;
 use OpenOrchestra\BaseApi\Context\GroupContext;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;

--- a/ApiBundle/Transformer/TemplateFlexTransformer.php
+++ b/ApiBundle/Transformer/TemplateFlexTransformer.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\ApiBundle\Transformer;
 
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\Backoffice\NavigationPanel\Strategies\TreeTemplateFlexPanelStrategy;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;
 use OpenOrchestra\BaseApi\Transformer\AbstractSecurityCheckerAwareTransformer;

--- a/ApiBundle/Transformer/TemplateTransformer.php
+++ b/ApiBundle/Transformer/TemplateTransformer.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\ApiBundle\Transformer;
 
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\Backoffice\NavigationPanel\Strategies\TreeTemplatePanelStrategy;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;
 use OpenOrchestra\BaseApi\Transformer\AbstractSecurityCheckerAwareTransformer;

--- a/ApiBundle/Transformer/ThemeTransformer.php
+++ b/ApiBundle/Transformer/ThemeTransformer.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\ApiBundle\Transformer;
 
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;
 use OpenOrchestra\ModelInterface\Model\ThemeInterface;
 use OpenOrchestra\BaseApi\Transformer\AbstractSecurityCheckerAwareTransformer;

--- a/ApiBundle/Transformer/TrashItemTransformer.php
+++ b/ApiBundle/Transformer/TrashItemTransformer.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\ApiBundle\Transformer;
 
-use OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException;
+use OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException;
 use OpenOrchestra\Backoffice\NavigationPanel\Strategies\AdministrationPanelStrategy;
 use OpenOrchestra\BaseApi\Facade\FacadeInterface;
 use OpenOrchestra\BaseApi\Transformer\AbstractSecurityCheckerAwareTransformer;


### PR DESCRIPTION
[OO-BUFGIX] Fix dependency between BaseApi and ApiBundle, move TransformerParameterTypeException
[OO-DEPRECATED] The ``OpenOrchestra\ApiBundle\Exceptions\TransformerParameterTypeException`` class is deprecated since version 1.2.0 and will be removed in 1.3.0, use ``OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException``

https://github.com/open-orchestra/open-orchestra-base-api-bundle/pull/81
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1631
https://github.com/open-orchestra/open-orchestra-media-admin-bundle/pull/218