### PR TITLE
use contentId instead id

### DIFF
--- a/Backoffice/EventSubscriber/ContentSearchSubscriber.php
+++ b/Backoffice/EventSubscriber/ContentSearchSubscriber.php
@@ -120,8 +120,8 @@ class ContentSearchSubscriber implements EventSubscriberInterface
 
     /**
      * @param string $contentType
-     * @param string $operator
-     * @param string $keywords
+     * @param string $choiceType
+     * @param string $condition
      *
      * @return array
      */
@@ -132,7 +132,7 @@ class ContentSearchSubscriber implements EventSubscriberInterface
         $contents = $this->contentRepository->findByContentTypeAndCondition($language, $contentType, $choiceType, $condition);
 
         foreach ($contents as $content) {
-            $choices[$content->getId()] = $content->getName();
+            $choices[$content->getContentId()] = $content->getName();
         }
 
         return $choices;
@@ -146,8 +146,8 @@ class ContentSearchSubscriber implements EventSubscriberInterface
     protected function getChoice($contentId)
     {
         $choices = array();
-        $content = $this->contentRepository->find($contentId);
-        $choices[$content->getId()] = $content->getName();
+        $content = $this->contentRepository->findOneByContentId($contentId);
+        $choices[$content->getContentId()] = $content->getName();
 
         return $choices;
     }

--- a/Backoffice/Tests/EventSubscriber/ContentSearchSubscriberTest.php
+++ b/Backoffice/Tests/EventSubscriber/ContentSearchSubscriberTest.php
@@ -38,10 +38,10 @@ class ContentSearchSubscriberTest extends AbstractBaseTestCase
 
         $content1 = Phake::mock('OpenOrchestra\ModelInterface\Model\ContentInterface');
         Phake::when($content1)->getName()->thenReturn($this->contentName1);
-        Phake::when($content1)->getId()->thenReturn($this->contentId1);
+        Phake::when($content1)->getContentId()->thenReturn($this->contentId1);
         $content2 = Phake::mock('OpenOrchestra\ModelInterface\Model\ContentInterface');
         Phake::when($content2)->getName()->thenReturn($this->contentName2);
-        Phake::when($content2)->getId()->thenReturn($this->contentId2);
+        Phake::when($content2)->getContentId()->thenReturn($this->contentId2);
         $this->contentRepository = Phake::mock('OpenOrchestra\ModelInterface\Repository\ContentRepositoryInterface');
 
         Phake::when($this->contentRepository)->findByContentTypeAndCondition($language, $contentType, $choiceType, $jCondition)->thenReturn(array(


### PR DESCRIPTION
[OO-BUGFIX] Fix use contentId instead id in ContentSearchSubscriber

https://github.com/open-orchestra/open-orchestra-display-bundle/pull/216
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1667