### PR TITLE
Normalize oo_node_choice attr/class option.

### DIFF
--- a/Backoffice/Form/Type/Component/NodeChoiceType.php
+++ b/Backoffice/Form/Type/Component/NodeChoiceType.php
@@ -3,10 +3,11 @@
 namespace OpenOrchestra\Backoffice\Form\Type\Component;
 
 use OpenOrchestra\BaseBundle\Context\CurrentSiteIdInterface;
+use OpenOrchestra\DisplayBundle\Manager\TreeManager;
 use OpenOrchestra\ModelInterface\Repository\NodeRepositoryInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use OpenOrchestra\DisplayBundle\Manager\TreeManager;
 
 /**
  * Class NodeChoiceType
@@ -37,11 +38,30 @@ class NodeChoiceType extends AbstractType
         $resolver->setDefaults(
             array(
                 'choices' => $this->getChoices(),
-                'attr' => array(
-                    'class' => 'orchestra-node-choice'
-                )
             )
         );
+
+        /*
+         * Normalize 'attr' option to force presence of 'orchestra-node-choice' html class.
+         * This class is mandatory to trigger execution of following coffee function on field :
+         * OpenOrchestra.FormBehavior.NodeChoice.activateBehaviorOnElements().
+         */
+        $resolver->setNormalizer('attr', function (Options $options, $value) {
+            if (!is_array($value)) {
+                $value = array();
+            }
+
+            $classList = array();
+            if (array_key_exists('class', $value) && !empty($value['class'])) {
+                $classList = explode(' ', $value['class']);
+            }
+            if (!in_array('orchestra-node-choice', $classList)) {
+                $classList[] = 'orchestra-node-choice';
+            }
+            $value['class'] = implode(' ', $classList);
+
+            return $value;
+        });
     }
 
     /**

--- a/Backoffice/Tests/Form/Type/Component/NodeChoiceTypeTest.php
+++ b/Backoffice/Tests/Form/Type/Component/NodeChoiceTypeTest.php
@@ -89,9 +89,6 @@ class NodeChoiceTypeTest extends AbstractBaseTestCase
                     $this->nodeNodeId1 => ''.$this->nodeName1,
                     $this->nodeNodeId2 => '&#x2514;'.$this->nodeName2,
                 ),
-                'attr' => array(
-                    'class' => 'orchestra-node-choice'
-                )
         ));
     }
 }


### PR DESCRIPTION
This piece of code ensure that even if someone sets the `attr` option of a `oo_node_choice` field when adding it inside a form, the html class `orchestra-node-choice` will still be defined.
This class is used to target the field and trigger execution of coffee function `OpenOrchestra.FormBehavior.NodeChoice.activateBehaviorOnElements()`.