### PR TITLE
1 2 multi languages meta

### DIFF
--- a/ApiBundle/Facade/SiteFacade.php
+++ b/ApiBundle/Facade/SiteFacade.php
@@ -21,14 +21,14 @@ class SiteFacade extends AbstractFacade
     public $name;
 
     /**
-     * @Serializer\Type("string")
+     * @Serializer\Type("array<string>")
      */
     public $metaKeywords;
 
     /**
-     * @Serializer\Type("string")
+     * @Serializer\Type("array<string>")
      */
-    public $metaDescription;
+    public $metaDescriptions;
 
     /**
      * @Serializer\Type("boolean")

--- a/ApiBundle/Transformer/SiteTransformer.php
+++ b/ApiBundle/Transformer/SiteTransformer.php
@@ -32,7 +32,7 @@ class SiteTransformer extends AbstractSecurityCheckerAwareTransformer
         $facade->siteId = $site->getSiteId();
         $facade->name = $site->getName();
         $facade->metaKeywords = $site->getMetaKeywords();
-        $facade->metaDescription = $site->getMetaDescription();
+        $facade->metaDescriptions = $site->getMetaDescriptions();
         $facade->metaIndex = $site->getMetaIndex();
         $facade->metaFollow = $site->getMetaFollow();
         $facade->theme = $this->getTransformer('theme')->transform($site->getTheme());

--- a/Backoffice/Form/Type/SiteType.php
+++ b/Backoffice/Form/Type/SiteType.php
@@ -18,17 +18,24 @@ class SiteType extends AbstractType
     protected $siteClass;
     protected $translator;
     protected $templateRepository;
+    protected $frontLanguages;
 
     /**
      * @param string                      $siteClass
      * @param TranslatorInterface         $translator
      * @param TemplateRepositoryInterface $templateRepository
+     * @param array                       $frontLanguages
      */
-    public function __construct($siteClass, TranslatorInterface $translator, TemplateRepositoryInterface $templateRepository)
-    {
+    public function __construct(
+        $siteClass,
+        TranslatorInterface $translator,
+        TemplateRepositoryInterface $templateRepository,
+        array $frontLanguages
+    ){
         $this->siteClass = $siteClass;
         $this->translator = $translator;
         $this->templateRepository = $templateRepository;
+        $this->frontLanguages = \array_keys($frontLanguages);
     }
 
     /**
@@ -77,13 +84,15 @@ class SiteType extends AbstractType
                 'precision' => 2,
                 'attr' => array('help_text' => 'open_orchestra_backoffice.form.node.priority.helper'),
             ))
-            ->add('metaKeywords', 'text', array(
+            ->add('metaKeywords', 'oo_multi_languages_text', array(
                 'label' => 'open_orchestra_backoffice.form.website.meta_keywords',
                 'required' => false,
+                'languages' => $this->frontLanguages
             ))
-            ->add('metaDescription', 'text', array(
+            ->add('metaDescriptions', 'oo_multi_languages_text', array(
                 'label' => 'open_orchestra_backoffice.form.website.meta_description',
                 'required' => false,
+                'languages' => $this->frontLanguages
             ))
             ->add('metaIndex', 'checkbox', array(
                 'label' => 'open_orchestra_backoffice.form.website.meta_index',

--- a/Backoffice/Manager/NodeManager.php
+++ b/Backoffice/Manager/NodeManager.php
@@ -153,8 +153,15 @@ class NodeManager
         $newNode = clone $node;
         $newNode->setVersion(1);
         $newNode->setStatus($this->getEditableStatus($node));
-        $newNode->setLanguage($language);
         $newNode = $this->duplicateBlockAndArea($node, $newNode);
+
+        $siteId = $this->contextManager->getCurrentSiteId();
+        $site = $this->siteRepository->findOneBySiteId($siteId);
+        $newNode->setLanguage($language);
+        if ($site) {
+            $newNode->setMetaKeywords($site->getMetaKeywordsInLanguage($language));
+            $newNode->setMetaDescription($site->getMetaDescriptionInLanguage($language));
+        }
 
         $this->eventDispatcher->dispatch(NodeEvents::NODE_ADD_LANGUAGE, new NodeEvent($node));
 
@@ -341,8 +348,8 @@ class NodeManager
 
         $site = $this->siteRepository->findOneBySiteId($siteId);
         if ($site) {
-            $node->setMetaKeywords($site->getMetaKeywords());
-            $node->setMetaDescription($site->getMetaDescription());
+            $node->setMetaKeywords($site->getMetaKeywordsInLanguage($language));
+            $node->setMetaDescription($site->getMetaDescriptionInLanguage($language));
             $node->setMetaIndex($site->getMetaIndex());
             $node->setMetaFollow($site->getMetaFollow());
         }

--- a/Backoffice/Tests/Form/Type/SiteTypeTest.php
+++ b/Backoffice/Tests/Form/Type/SiteTypeTest.php
@@ -18,6 +18,7 @@ class SiteTypeTest extends AbstractBaseTestCase
 
     protected $siteClass = 'oo_site';
     protected $translator;
+    protected $languages = array('en', 'fr');
 
     /**
      * Set up the test
@@ -28,7 +29,7 @@ class SiteTypeTest extends AbstractBaseTestCase
         $repositoryTemplate = Phake::mock('OpenOrchestra\ModelInterface\Repository\TemplateRepositoryInterface');
         Phake::when($this->translator)->trans(Phake::anyParameters())->thenReturn('foo');
 
-        $this->form = new SiteType($this->siteClass, $this->translator, $repositoryTemplate);
+        $this->form = new SiteType($this->siteClass, $this->translator, $repositoryTemplate, $this->languages);
     }
 
     /**

--- a/Backoffice/Tests/Manager/NodeManagerTest.php
+++ b/Backoffice/Tests/Manager/NodeManagerTest.php
@@ -39,6 +39,8 @@ class NodeManagerTest extends AbstractBaseTestCase
     protected $siteRepository;
     protected $eventDispatcher;
     protected $statusRepository;
+    protected $metaKeywords = 'fake keyword';
+    protected $metaDescription = 'fake description';
 
     /**
      * Set up the test
@@ -49,8 +51,8 @@ class NodeManagerTest extends AbstractBaseTestCase
         Phake::when($theme)->getName()->thenReturn('fakeNameTheme');
         $site = Phake::mock('OpenOrchestra\ModelInterface\Model\SiteInterface');
         Phake::when($site)->getTheme()->thenReturn($theme);
-        Phake::when($site)->getMetaKeywords()->thenReturn('fake keyword');
-        Phake::when($site)->getMetaDescription()->thenReturn('fake description');
+        Phake::when($site)->getMetaKeywordsInLanguage(Phake::anyParameters())->thenReturn($this->metaKeywords);
+        Phake::when($site)->getMetaDescriptionInLanguage(Phake::anyParameters())->thenReturn($this->metaDescription);
         Phake::when($site)->getMetaIndex()->thenReturn(true);
         Phake::when($site)->getMetaFollow()->thenReturn(true);
 
@@ -132,6 +134,8 @@ class NodeManagerTest extends AbstractBaseTestCase
         Phake::verify($alteredNode)->setVersion(1);
         Phake::verify($alteredNode)->setStatus(null);
         Phake::verify($alteredNode)->setLanguage($language);
+        Phake::verify($alteredNode)->setMetaKeywords($this->metaKeywords);
+        Phake::verify($alteredNode)->setMetaDescription($this->metaDescription);
         Phake::verify($this->eventDispatcher)->dispatch(Phake::anyParameters());
     }
 
@@ -299,8 +303,8 @@ class NodeManagerTest extends AbstractBaseTestCase
         $this->assertEquals($language, $node->getLanguage());
         $this->assertEquals(NodeInterface::THEME_DEFAULT, $node->getTheme());
         $this->assertTrue($node->hasDefaultSiteTheme());
-        $this->assertEquals('fake keyword', $node->getMetaKeywords());
-        $this->assertEquals('fake description', $node->getMetaDescription());
+        $this->assertEquals($this->metaKeywords, $node->getMetaKeywords());
+        $this->assertEquals($this->metaDescription, $node->getMetaDescription());
         $this->assertEquals(0, $node->getOrder());
         $this->assertEquals($status, $node->getStatus());
         $this->assertEquals(true, $node->getMetaIndex());

--- a/BackofficeBundle/Resources/config/form.yml
+++ b/BackofficeBundle/Resources/config/form.yml
@@ -153,6 +153,7 @@ services:
             - %open_orchestra_model.document.site.class%
             - @translator
             - @open_orchestra_model.repository.template
+            - %open_orchestra_backoffice.orchestra_choice.front_language%
         tags:
             - { name: form.type, alias: oo_site }
     open_orchestra_backoffice.type.site_alias:

--- a/BackofficeBundle/Resources/public/less/smartadminPatches/form.less
+++ b/BackofficeBundle/Resources/public/less/smartadminPatches/form.less
@@ -101,3 +101,7 @@ input.focusable {
     border: 0px;
     height: 0px;
 }
+
+div.tab-pane > div.form-group>input[type="text"] {
+    border-top: 0px;
+}

--- a/BackofficeBundle/Resources/public/less/smartadminPatches/form.less
+++ b/BackofficeBundle/Resources/public/less/smartadminPatches/form.less
@@ -102,6 +102,6 @@ input.focusable {
     height: 0px;
 }
 
-div.tab-pane > div.form-group>input[type="text"] {
+div.tab-pane>div.form-group>input[type="text"], div.tab-pane>div.form-group>textarea {
     border-top: 0px;
 }

--- a/BackofficeBundle/Resources/public/less/smartadminPatches/tab.less
+++ b/BackofficeBundle/Resources/public/less/smartadminPatches/tab.less
@@ -3,22 +3,22 @@
 }
 .form-group {
     .tab-content > .tab-pane {
-        display: block;
         margin-bottom: -32px;
         position: relative;
         visibility: visible;
         z-index: 1;
     }
+
     .tab-content > .active ~ .tab-pane {
         top: -32px;
     }
-    
+
     .tab-content > .active {
         margin-bottom: 0;
         top: 0;
         z-index: 2;
     }
-    
+
     .tab-content .form-group {
         margin-bottom: 0;
     }


### PR DESCRIPTION
[OO-FEATURE] On a site, the default Meta Description and Meta Keywords can now be personnalized per language
https://github.com/open-orchestra/open-orchestra-model-interface/pull/195
https://github.com/open-orchestra/open-orchestra-mongo-libs/pull/33
https://github.com/open-orchestra/open-orchestra-model-bundle/pull/595
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1757
https://github.com/open-orchestra/open-orchestra-front-bundle/pull/171