### PR TITLE
Create the OrchestraViewConfigurator before dom:ready

### DIFF
--- a/BackofficeBundle/Resources/public/coffee/viewConfigurator.coffee
+++ b/BackofficeBundle/Resources/public/coffee/viewConfigurator.coffee
@@ -41,5 +41,4 @@ OrchestraViewConfigurator = ->
         return view
     return @baseConfigurations[action]
 
-jQuery ->
-  window.appConfigurationView = new OrchestraViewConfigurator()
+appConfigurationView = new OrchestraViewConfigurator()

--- a/GruntTasks/Options/concat.orchestrajs.js
+++ b/GruntTasks/Options/concat.orchestrajs.js
@@ -6,7 +6,6 @@ module.exports = {
         'web/built/openorchestrabackoffice/js/tinyMCE/activateTinyMCE.js',
         'web/built/openorchestrabackoffice/js/tinyMCE/bbcode2htmlConfigurator.js',
         'web/built/openorchestrabackoffice/js/tinyMCE/html2bbcodeConfigurator.js',
-        'web/built/openorchestrabackoffice/js/viewConfigurator.js',
         'web/built/openorchestrabackoffice/js/setUpCallAjax.js',
         'web/built/openorchestrabackoffice/js/OrchestraView.js',
         'web/built/openorchestrabackoffice/js/OrchestraModalView.js',
@@ -90,6 +89,9 @@ module.exports = {
         'web/built/openorchestrabackoffice/js/table/TableviewRestoreAction.js',
         'web/built/openorchestrabackoffice/js/table/TableviewCollectionView.js',
         'web/built/openorchestrabackoffice/js/table/tableviewLoader.js',
+
+        //--[ VIEWS CONFIGURATION ]--//
+        'web/built/openorchestrabackoffice/js/viewConfigurator.js',
 
         //--[ USER ]--//
         'web/built/openorchestrauseradmin/js/user/*.js'


### PR DESCRIPTION
Currently when overriding an OrchestraView object (using the appConfigurationView's configuration) we also need to register a specific route for the case of a refresh of the page. This is due to the fact that the appConfigurationView is not registered before the dom:ready event and that the backbone router is started too early in the process (so my custom configuration is not yet registered when the router tries to match a route).

This change fixes this issue and has no functionnal impact on the application since it's only about JS object creation.