### PR TITLE
Fix merge form block strategy

### DIFF
--- a/Backoffice/EventSubscriber/AbstractModulableTypeSubscriber.php
+++ b/Backoffice/EventSubscriber/AbstractModulableTypeSubscriber.php
@@ -7,8 +7,11 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 
+@trigger_error('The '.__NAMESPACE__.'\AbstractModulableTypeSubscriber class is deprecated since version 1.2.0 and will be removed in 1.3.0', E_USER_DEPRECATED);
+
 /**
  * Class AbstractModulableTypeSubscriber
+ * @deprecated  deprecated since version 1.2.0 and will be removed in version 1.3.0
  */
 abstract class AbstractModulableTypeSubscriber implements EventSubscriberInterface
 {

--- a/Backoffice/EventSubscriber/BlockFormTypeSubscriber.php
+++ b/Backoffice/EventSubscriber/BlockFormTypeSubscriber.php
@@ -41,10 +41,6 @@ class BlockFormTypeSubscriber implements EventSubscriberInterface
         if (null !== $block) {
             $blockAttributes = array();
             foreach ($event->getForm()->all() as $key => $children) {
-                if ( 'submit' === $key) {
-                    continue;
-                }
-
                 $value = $children->getData();
 
                 if (in_array($key, $this->fixedParameters)) {

--- a/Backoffice/EventSubscriber/BlockFormTypeSubscriber.php
+++ b/Backoffice/EventSubscriber/BlockFormTypeSubscriber.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace OpenOrchestra\Backoffice\EventSubscriber;
+
+use Doctrine\Common\Util\Inflector;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * Class BlockFormTypeSubscriber
+ */
+class BlockFormTypeSubscriber implements EventSubscriberInterface
+{
+    protected $fixedParameters;
+
+    /**
+     * @return array The event names to listen to
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FormEvents::SUBMIT => 'submit',
+        );
+    }
+
+    /**
+     * @param array $fixedParameters
+     */
+    public function __construct(array $fixedParameters)
+    {
+        $this->fixedParameters = $fixedParameters;
+    }
+
+    /**
+     * @param FormEvent $event
+     */
+    public function submit(FormEvent $event)
+    {
+        $block = $event->getForm()->getData();
+        if (null !== $block) {
+            $blockAttributes = array();
+            foreach ($event->getForm()->all() as $key => $children) {
+                if ( 'submit' === $key) {
+                    continue;
+                }
+
+                $value = $children->getData();
+
+                if (in_array($key, $this->fixedParameters)) {
+                    $setter = 'set' . Inflector::classify($key);
+                    $block->$setter($value);
+                    continue;
+                }
+                if (is_string($value) && is_array(json_decode($value, true))) {
+                    $value = json_decode($value, true);
+                }
+                $blockAttributes[$key] = $value;
+            }
+            $block->setAttributes($blockAttributes);
+        }
+    }
+}

--- a/Backoffice/EventSubscriber/BlockTypeSubscriber.php
+++ b/Backoffice/EventSubscriber/BlockTypeSubscriber.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormFactoryInterface;
 
-@trigger_error('The '.__NAMESPACE__.'\AbstractModulableTypeSubscriber class is deprecated since version 1.2.0 and will be removed in 1.3.0.  use BlockFormTypeSubscriber', E_USER_DEPRECATED);
+@trigger_error('The '.__NAMESPACE__.'\BlockTypeSubscriber class is deprecated since version 1.2.0 and will be removed in 1.3.0.  use BlockFormTypeSubscriber', E_USER_DEPRECATED);
 
 /**
  * Class BlockTypeSubscriber

--- a/Backoffice/EventSubscriber/BlockTypeSubscriber.php
+++ b/Backoffice/EventSubscriber/BlockTypeSubscriber.php
@@ -8,8 +8,11 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormFactoryInterface;
 
+@trigger_error('The '.__NAMESPACE__.'\AbstractModulableTypeSubscriber class is deprecated since version 1.2.0 and will be removed in 1.3.0.  use BlockFormTypeSubscriber', E_USER_DEPRECATED);
+
 /**
  * Class BlockTypeSubscriber
+ * @deprecated  deprecated since version 1.2.0 and will be removed in version 1.3.0, use BlockFormTypeSubscriber
  */
 class BlockTypeSubscriber extends AbstractModulableTypeSubscriber
 {

--- a/Backoffice/Form/Type/BlockType.php
+++ b/Backoffice/Form/Type/BlockType.php
@@ -2,12 +2,11 @@
 
 namespace OpenOrchestra\Backoffice\Form\Type;
 
-use OpenOrchestra\Backoffice\EventSubscriber\BlockTypeSubscriber;
 use OpenOrchestra\Backoffice\Form\DataTransformer\BlockToArrayTransformer;
 use OpenOrchestra\BackofficeBundle\StrategyManager\GenerateFormManager;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -17,26 +16,22 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 class BlockType extends AbstractType
 {
     protected $generateFormManager;
-    protected $fixedParameters;
-    protected $formFactory;
     protected $blockToArrayTransformer;
+    protected $blockFormTypeSubscriber;
 
     /**
-     * @param GenerateFormManager     $generateFormManager
-     * @param array                   $fixedParameters
-     * @param FormFactoryInterface    $formFactory
-     * @param BlockToArrayTransformer $blockToArrayTransformer
+     * @param GenerateFormManager      $generateFormManager
+     * @param BlockToArrayTransformer  $blockToArrayTransformer
+     * @param EventSubscriberInterface $blockFormTypeSubscriber
      */
     public function __construct(
         GenerateFormManager $generateFormManager,
-        $fixedParameters,
-        FormFactoryInterface $formFactory,
-        BlockToArrayTransformer $blockToArrayTransformer
+        BlockToArrayTransformer $blockToArrayTransformer,
+        EventSubscriberInterface $blockFormTypeSubscriber
     ) {
         $this->generateFormManager = $generateFormManager;
-        $this->fixedParameters = $fixedParameters;
-        $this->formFactory = $formFactory;
         $this->blockToArrayTransformer = $blockToArrayTransformer;
+        $this->blockFormTypeSubscriber = $blockFormTypeSubscriber;
     }
 
     /**
@@ -65,11 +60,8 @@ class BlockType extends AbstractType
         $builder->setAttribute('template', $this->generateFormManager->getTemplate($options['data']));
 
         $builder->addViewTransformer($this->blockToArrayTransformer);
-        $builder->addEventSubscriber(
-            new BlockTypeSubscriber(
-                $this->generateFormManager, $this->fixedParameters, $this->formFactory, $options['blockPosition']
-            )
-        );
+        $builder->addEventSubscriber($this->blockFormTypeSubscriber);
+
         if (array_key_exists('disabled', $options)) {
             $builder->setAttribute('disabled', $options['disabled']);
         }

--- a/Backoffice/GenerateForm/Strategies/AbstractBlockStrategy.php
+++ b/Backoffice/GenerateForm/Strategies/AbstractBlockStrategy.php
@@ -39,4 +39,12 @@ abstract class AbstractBlockStrategy extends AbstractType implements GenerateFor
     {
         return array();
     }
+
+    /**
+     * @return string
+     */
+    public function getParent()
+    {
+        return 'oo_block';
+    }
 }

--- a/Backoffice/GenerateForm/Strategies/ContentListStrategy.php
+++ b/Backoffice/GenerateForm/Strategies/ContentListStrategy.php
@@ -61,7 +61,7 @@ class ContentListStrategy extends AbstractBlockStrategy
     {
         return array(
             'contentNodeId' => NodeInterface::ROOT_NODE_ID,
-            'characterNumber' => '50',
+            'characterNumber' => 50,
             'contentTemplate' => '',
         );
     }

--- a/Backoffice/Tests/EventSubscriber/BlockFormTypeSubscriberTest.php
+++ b/Backoffice/Tests/EventSubscriber/BlockFormTypeSubscriberTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace OpenOrchestra\Backoffice\Tests\EventSubscriber;
+
+use OpenOrchestra\Backoffice\EventSubscriber\BlockFormTypeSubscriber;
+use OpenOrchestra\BaseBundle\Tests\AbstractTest\AbstractBaseTestCase;
+use Phake;
+use OpenOrchestra\Backoffice\EventSubscriber\BlockTypeSubscriber;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * Class BlockTypeSubscriberTest
+ */
+class BlockFormTypeSubscriberTest extends AbstractBaseTestCase
+{
+    /**
+     * @var BlockTypeSubscriber
+     */
+    protected $subscriber;
+
+    protected $form;
+    protected $event;
+    protected $block;
+    protected $fixedParameters;
+
+    /**
+     * Set up the test
+     */
+    public function setUp()
+    {
+        $this->block = Phake::mock('OpenOrchestra\ModelInterface\Model\BlockInterface');
+
+        $this->form = Phake::mock('Symfony\Component\Form\Form');
+        Phake::when($this->form)->getData()->thenReturn($this->block);
+
+        $this->event = Phake::mock('Symfony\Component\Form\FormEvent');
+        Phake::when($this->event)->getForm()->thenReturn($this->form);
+
+        $this->fixedParameters = array('component', 'label', 'class', 'id', 'max_age');
+
+        $this->subscriber = new BlockFormTypeSubscriber($this->fixedParameters);
+    }
+
+    /**
+     * Test instance
+     */
+    public function testInstance()
+    {
+        $this->assertInstanceOf('Symfony\Component\EventDispatcher\EventSubscriberInterface', $this->subscriber);
+    }
+
+    /**
+     * Test subscribed events
+     */
+    public function testEventSubscribed()
+    {
+        $this->assertArrayHasKey(FormEvents::SUBMIT, $this->subscriber->getSubscribedEvents());
+    }
+
+    /**
+     * Test submit
+     */
+    public function testsubmit()
+    {
+        $subForm1 = Phake::mock('Symfony\Component\Form\FormInterface');
+        Phake::when($subForm1)->getData()->thenReturn('test');
+        $subForm2 = Phake::mock('Symfony\Component\Form\FormInterface');
+        Phake::when($subForm2)->getData()->thenReturn('sub');
+        $subForm3 = Phake::mock('Symfony\Component\Form\FormInterface');
+        Phake::when($subForm3)->getData()->thenReturn(array('1','2'));
+
+        $subForms = array(
+            'label' => $subForm1,
+            'fakeAttribute' => $subForm2,
+            'fakeArrayAttribute' => $subForm3,
+        );
+        Phake::when($this->form)->all()->thenReturn($subForms);
+
+        $blockAttributes = array(
+            'fakeAttribute' => 'sub',
+            'fakeArrayAttribute' => array('1','2'),
+        );
+
+        $this->subscriber->submit($this->event);
+
+        Phake::verify($this->block)->setAttributes($blockAttributes);
+    }
+}

--- a/Backoffice/Tests/EventSubscriber/BlockTypeSubscriberTest.php
+++ b/Backoffice/Tests/EventSubscriber/BlockTypeSubscriberTest.php
@@ -9,6 +9,7 @@ use Symfony\Component\Form\FormEvents;
 
 /**
  * Class BlockTypeSubscriberTest
+ * @deprecated  deprecated since version 1.2.0 and will be removed in version 1.3.0, use BlockFormTypeSubscriber
  */
 class BlockTypeSubscriberTest extends AbstractBaseTestCase
 {

--- a/Backoffice/Tests/Form/Type/BlockTypeTest.php
+++ b/Backoffice/Tests/Form/Type/BlockTypeTest.php
@@ -18,8 +18,6 @@ class BlockTypeTest extends AbstractBaseTestCase
 
     protected $templateName = 'template';
     protected $generateFormManager;
-    protected $fixedParameters;
-    protected $formFactory;
 
     /**
      * Set up the test
@@ -28,12 +26,11 @@ class BlockTypeTest extends AbstractBaseTestCase
     {
         $this->generateFormManager = Phake::mock('OpenOrchestra\BackofficeBundle\StrategyManager\GenerateFormManager');
         $blockToArrayTransformer = Phake::mock('OpenOrchestra\Backoffice\Form\DataTransformer\BlockToArrayTransformer');
+        $blockFormTypeSubscriber = Phake::mock('OpenOrchestra\Backoffice\EventSubscriber\BlockFormTypeSubscriber');
 
         Phake::when($this->generateFormManager)->getTemplate(Phake::anyParameters())->thenReturn($this->templateName);
-        $this->fixedParameters = array('component', 'submit', 'label', 'class', 'id', 'max_age');
-        $this->formFactory = Phake::mock('Symfony\Component\Form\FormFactoryInterface');
 
-        $this->blockType = new BlockType($this->generateFormManager, $this->fixedParameters, $this->formFactory, $blockToArrayTransformer);
+        $this->blockType = new BlockType($this->generateFormManager, $blockToArrayTransformer, $blockFormTypeSubscriber);
     }
 
     /**

--- a/BackofficeBundle/Controller/BlockController.php
+++ b/BackofficeBundle/Controller/BlockController.php
@@ -46,7 +46,8 @@ class BlockController extends AbstractEditionRoleController
             $options['method'] = 'PATCH';
         }
 
-        $form = parent::createForm('oo_block', $block, $options);
+        $formType = $this->get('open_orchestra_backoffice.generate_form_manager')->getFormType($block);
+        $form = $this->createForm($formType, $block, $options);
         $form->handleRequest($request);
 
         if ('PATCH' !== $request->getMethod()) {

--- a/BackofficeBundle/Resources/config/form.yml
+++ b/BackofficeBundle/Resources/config/form.yml
@@ -125,12 +125,11 @@ services:
             - { name: form.type}
     # Block form type
     open_orchestra_backoffice.type.block:
-        class: %open_orchestra_backoffice.type.block.class%
+        class: '%open_orchestra_backoffice.type.block.class%'
         arguments:
-            - @open_orchestra_backoffice.generate_form_manager
-            - %open_orchestra_backoffice.block.fixed_attributes%
-            - @form.factory
-            - @open_orchestra_backoffice.transformer.block_to_array
+            - '@open_orchestra_backoffice.generate_form_manager'
+            - '@open_orchestra_backoffice.transformer.block_to_array'
+            - '@open_orchestra_backoffice.subscriber.block_form_type'
         tags:
             - { name: form.type, alias: oo_block }
     open_orchestra_backoffice.type.existing_block_choice:

--- a/BackofficeBundle/Resources/config/subscriber.yml
+++ b/BackofficeBundle/Resources/config/subscriber.yml
@@ -14,6 +14,7 @@ parameters:
     open_orchestra_backoffice.subscriber.create_transverse_node.class: OpenOrchestra\Backoffice\EventSubscriber\CreateTransverseNodeSubscriber
     open_orchestra_backoffice.subscriber.create_root_node.class: OpenOrchestra\Backoffice\EventSubscriber\CreateRootNodeSubscriber
     open_orchestra_backoffice.subscriber.update_site_alias_redirection_site.class: OpenOrchestra\Backoffice\EventSubscriber\UpdateSiteAliasRedirectionSiteSubscriber
+    open_orchestra_backoffice.subscriber.block_form_type.class: OpenOrchestra\Backoffice\EventSubscriber\BlockFormTypeSubscriber
 
 services:
     open_orchestra_backoffice.subscriber.update_child_node_path:
@@ -124,5 +125,11 @@ services:
             - @object_manager
             - @open_orchestra_backoffice.manager.redirection
             - @open_orchestra_model.repository.node
+        tags:
+            - { name: kernel.event_subscriber }
+    open_orchestra_backoffice.subscriber.block_form_type:
+        class: '%open_orchestra_backoffice.subscriber.block_form_type.class%'
+        arguments:
+            - '%open_orchestra_backoffice.block.fixed_attributes%'
         tags:
             - { name: kernel.event_subscriber }

--- a/BackofficeBundle/StrategyManager/GenerateFormManager.php
+++ b/BackofficeBundle/StrategyManager/GenerateFormManager.php
@@ -70,8 +70,30 @@ class GenerateFormManager
      * @throws MissingGenerateFormStrategyException
      *
      * @return GenerateFormInterface
+     *
+     * @deprecated  deprecated since version 1.2.0 and will be removed in version 1.3.0, use getFormType
      */
     public function createForm(BlockInterface $block)
+    {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.2.0 and will be removed in 1.3.0. Use the '.__CLASS__.'::getFormType method instead.', E_USER_DEPRECATED);
+        /** @var GenerateFormInterface $strategy */
+        foreach ($this->strategies as $strategy) {
+            if ($strategy->support($block)) {
+                return $strategy;
+            }
+        }
+
+        throw new MissingGenerateFormStrategyException();
+    }
+
+    /**
+     * @param BlockInterface $block
+     *
+     * @throws MissingGenerateFormStrategyException
+     *
+     * @return GenerateFormInterface
+     */
+    public function getFormType(BlockInterface $block)
     {
         /** @var GenerateFormInterface $strategy */
         foreach ($this->strategies as $strategy) {

--- a/BackofficeBundle/Tests/Functional/EventSubscriber/BlockFormTypeSubscriberTest.php
+++ b/BackofficeBundle/Tests/Functional/EventSubscriber/BlockFormTypeSubscriberTest.php
@@ -14,11 +14,11 @@ use OpenOrchestra\ModelInterface\Repository\ReadContentRepositoryInterface;
 use OpenOrchestra\ModelInterface\Repository\RepositoryTrait\KeywordableTraitInterface;
 
 /**
- * Class BlockTypeSubscriberTest
+ * Class BlockFormTypeSubscriberTest
  *
  * @group backofficeTest
  */
-class BlockTypeSubscriberTest extends AbstractAuthentificatedTest
+class BlockFormTypeSubscriberTest extends AbstractAuthentificatedTest
 {
     /**
      * @var FormFactoryInterface
@@ -46,15 +46,15 @@ class BlockTypeSubscriberTest extends AbstractAuthentificatedTest
         $block->setComponent(VideoStrategy::NAME);
         $block->addAttribute('videoType', 'youtube');
         $block->addAttribute('youtubeFs', true);
-
-        $form = $this->formFactory->create('oo_block', $block, array('csrf_protection' => false));
+        $formType =  static::$kernel->getContainer()->get('open_orchestra_backoffice.generate_form_manager')->getFormType($block);
+        $form = $this->formFactory->create($formType, $block, array('csrf_protection' => false));
 
         $form->submit(array(
             'id' => 'testId',
             'class' => 'testClass',
             'videoType' => 'youtube',
             'youtubeVideoId' => 'videoId',
-            'youtubeAutoplay' => '1',
+            'youtubeAutoplay' => true,
         ));
 
         $this->assertTrue($form->isSynchronized());
@@ -63,7 +63,7 @@ class BlockTypeSubscriberTest extends AbstractAuthentificatedTest
         $this->assertBlock($data);
         $this->assertSame('videoId', $data->getAttribute('youtubeVideoId'));
         $this->assertTrue($data->getAttribute('youtubeAutoplay'));
-        $this->assertNull($data->getAttribute('youtubeFs'));
+        $this->assertFalse($data->getAttribute('youtubeFs'));
     }
 
     /**
@@ -76,8 +76,9 @@ class BlockTypeSubscriberTest extends AbstractAuthentificatedTest
     {
         $block = new Block();
         $block->setComponent($component);
+        $formType =  static::$kernel->getContainer()->get('open_orchestra_backoffice.generate_form_manager')->getFormType($block);
 
-        $form = $this->formFactory->create('oo_block', $block, array('csrf_protection' => false));
+        $form = $this->formFactory->create($formType, $block, array('csrf_protection' => false));
 
         $submittedValue = array_merge(array('id' => 'testId', 'class' => 'testClass'), $value);
         $form->submit($submittedValue);
@@ -97,21 +98,22 @@ class BlockTypeSubscriberTest extends AbstractAuthentificatedTest
     public function provideComponentAndData()
     {
         return array(
-            array(GalleryStrategy::NAME, array(
-                'pictures' => array(
-                    'media1',
-                    'media2'
-                )
-            )),
             array(ContentListStrategy::NAME, array(
-                'contentNodeId' => 'news',
+                'contentNodeId' => 'root',
+                'contentSearch' => array(
+                  'contentType' => 'news',
+                  'choiceType' => 'choice_and',
+                  'keywords' => null,
+                ),
+                'characterNumber' => 150,
                 'contentTemplateEnabled' => true,
             )),
             array(ConfigurableContentStrategy::NAME, array(
                 'contentSearch' => array(
                     'contentType' => 'car',
-                    'keywords' => null,
                     'choiceType' => ReadContentRepositoryInterface::CHOICE_AND,
+                    'keywords' => null,
+                    'contentId' => null,
                 ),
                 'contentTemplateEnabled' => true,
             ))
@@ -128,7 +130,9 @@ class BlockTypeSubscriberTest extends AbstractAuthentificatedTest
     {
         $block = new Block();
         $block->setComponent($component);
-        $form = $this->formFactory->create('oo_block', $block, array('csrf_protection' => false));
+        $formType =  static::$kernel->getContainer()->get('open_orchestra_backoffice.generate_form_manager')->getFormType($block);
+
+        $form = $this->formFactory->create($formType, $block, array('csrf_protection' => false));
         $submittedValue = array_merge(array('id' => 'testId', 'class' => 'testClass'), $value);
         $value['contentSearch']['keywords'] = $this->replaceKeywordLabelById($value['contentSearch']['keywords']);
         $form->submit($submittedValue);
@@ -148,13 +152,16 @@ class BlockTypeSubscriberTest extends AbstractAuthentificatedTest
     public function provideComponentAndDataAndTransformedValue()
     {
         return array(
-                array(ContentListStrategy::NAME, array(
-                        'contentNodeId' => 'news',
-                        'contentTemplateEnabled' => true,
-                        'contentSearch' => array(
-                                'keywords' => 'lorem AND ipsum',
-                            )
-                )),
+            array(ContentListStrategy::NAME, array(
+                'contentNodeId' => 'root',
+                'contentTemplateEnabled' => true,
+                'characterNumber' => 150,
+                'contentSearch' => array(
+                    'contentType' => 'news',
+                    'choiceType' => ReadContentRepositoryInterface::CHOICE_AND,
+                    'keywords' => 'lorem AND ipsum',
+                    )
+            )),
         );
     }
 

--- a/BackofficeBundle/Tests/StrategyManager/GenerateFormManagerTest.php
+++ b/BackofficeBundle/Tests/StrategyManager/GenerateFormManagerTest.php
@@ -62,7 +62,7 @@ class GenerateFormManagerTest extends AbstractBaseTestCase
     /**
      * Test getDefaultConfiguration with Exception
      *
-     * @expectedException OpenOrchestra\Backoffice\Exception\MissingGenerateFormStrategyException
+     * @expectedException \OpenOrchestra\Backoffice\Exception\MissingGenerateFormStrategyException
      */
     public function testGetDefaultConfigurationWithException()
     {
@@ -83,7 +83,7 @@ class GenerateFormManagerTest extends AbstractBaseTestCase
     /**
      * Test getRequiredUriParameter with Exception
      *
-     * @expectedException OpenOrchestra\Backoffice\Exception\MissingGenerateFormStrategyException
+     * @expectedException \OpenOrchestra\Backoffice\Exception\MissingGenerateFormStrategyException
      */
     public function testGetRequiredUriParameterWithException()
     {
@@ -92,6 +92,7 @@ class GenerateFormManagerTest extends AbstractBaseTestCase
 
     /**
      * Test Create form
+     * @deprecated  deprecated since version 1.2.0 and will be removed in version 1.3.0, use getFormType
      */
     public function testCreateForm()
     {
@@ -101,12 +102,30 @@ class GenerateFormManagerTest extends AbstractBaseTestCase
 
     /**
      * Test Create form with Exception
-     *
-     * @expectedException OpenOrchestra\Backoffice\Exception\MissingGenerateFormStrategyException
+     * @deprecated  deprecated since version 1.2.0 and will be removed in version 1.3.0, use getFormType
+     * @expectedException \OpenOrchestra\Backoffice\Exception\MissingGenerateFormStrategyException
      */
     public function testCreateFormWithException()
     {
         $this->exceptionManager->createForm($this->block);
+    }
+
+    /**
+     * Test get form
+     */
+    public function testGetFormType()
+    {
+        $strategy = $this->manager->getFormType($this->block);
+        $this->assertSame($this->strategy1, $strategy);
+    }
+
+    /**
+     * Test Create form with Exception
+     * @expectedException \OpenOrchestra\Backoffice\Exception\MissingGenerateFormStrategyException
+     */
+    public function testGetFormTypeWithException()
+    {
+        $this->exceptionManager->getFormType($this->block);
     }
 
     /**
@@ -123,7 +142,7 @@ class GenerateFormManagerTest extends AbstractBaseTestCase
     /**
      * Test get template with Exception
      *
-     * @expectedException OpenOrchestra\Backoffice\Exception\MissingGenerateFormStrategyException
+     * @expectedException \OpenOrchestra\Backoffice\Exception\MissingGenerateFormStrategyException
      */
     public function testGetTemplateWithException()
     {


### PR DESCRIPTION
[OO-DEPRECATED] AbstractModulableTypeSubscriber class is deprecated since version 1.2.0 and will be removed in 1.3.0
[OO-DEPRECATED] BlockTypeSubscriber class is deprecated since version 1.2.0 and will be removed in 1.3.0.  use BlockFormTypeSubscriber
[OO-DEPRECATED] GenerateFormManager:createForm method is deprecated since version 1.2.0 and will be removed in 1.3.0.  use getFormType
[OO-BUGFIX] Fix merge form block strategy with transformer and subscriber
