### PR TITLE
update fos alpha3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "open-orchestra/open-orchestra-display-bundle": "self.version",
     "open-orchestra/open-orchestra-model-interface": "self.version",
     "open-orchestra/open-orchestra-user-bundle": "self.version",
-    "friendsofsymfony/user-bundle": "@dev"
+    "friendsofsymfony/user-bundle": "@alpha"
   },
 
   "require-dev": {


### PR DESCRIPTION
[OO-BCBREAK] version of friendsofsymfony/user-bundle is fixed to 2.0.0 alpha3

https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1801
https://github.com/open-orchestra/open-orchestra-elastica-bundle/pull/50
https://github.com/open-orchestra/open-orchestra-workflow-function-bundle/pull/141
https://github.com/open-orchestra/open-orchestra/pull/992