### PR TITLE
fix refresh datable when remove element

### DIFF
--- a/BackofficeBundle/Resources/public/coffee/dataTable/DataTableView.coffee
+++ b/BackofficeBundle/Resources/public/coffee/dataTable/DataTableView.coffee
@@ -240,7 +240,7 @@ class DataTableView extends OrchestraView
   ###
   draw: (tableId) ->
     if tableId == @options.tableId and @api?
-        @api.draw()
+        @api.draw(false)
 
   ###*
   * @param {string} tableId


### PR DESCRIPTION
[OO-BUGFIX] No redirect to page 1, when an element of a datable is removed