### PR TITLE
get password and username and http header for oauth2 password strategy

### DIFF
--- a/UserAdminBundle/OAuth2/Strategy/ResourceOwnerPasswordGrantStrategy.php
+++ b/UserAdminBundle/OAuth2/Strategy/ResourceOwnerPasswordGrantStrategy.php
@@ -57,7 +57,7 @@ class ResourceOwnerPasswordGrantStrategy extends AbstractStrategy
     public function supportRequestToken(Request $request)
     {
         $clientExist = $request->getUser() && $request->getPassword();
-        $oauthParams = $request->get('grant_type') === 'password' && $request->get('username') && $request->get('password');
+        $oauthParams = $request->get('grant_type') === 'password' && $request->headers->get('username') && $request->headers->get('password');
 
         return $oauthParams && $clientExist;
     }
@@ -103,14 +103,14 @@ class ResourceOwnerPasswordGrantStrategy extends AbstractStrategy
     protected function getUser(Request $request)
     {
         // find the user
-        $user = $this->userRepository->findOneByUsername($request->get('username'));
+        $user = $this->userRepository->findOneByUsername($request->headers->get('username'));
         if (!$user) {
             throw new BadUserCredentialsHttpException();
         }
 
         // Check the validity of the password
         $encoder = $this->encoderFactory->getEncoder($user);
-        if (!$encoder->isPasswordValid($user->getPassword(), $request->get('password'), $user->getSalt())) {
+        if (!$encoder->isPasswordValid($user->getPassword(), $request->headers->get('password'), $user->getSalt())) {
             throw new BadUserCredentialsHttpException();
         }
 


### PR DESCRIPTION
[OO-MISC] The password strategy OAut2 take username and password in the http header.
[OO-BREAK] In the password strategy OAut2 the username and password must be in the request header

https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1823
https://github.com/open-orchestra/open-orchestra/pull/1000
https://github.com/open-orchestra/open-orchestra-docs/pull/224