### PR TITLE
1.1 fix content pagination count

### DIFF
--- a/ApiBundle/Controller/ContentController.php
+++ b/ApiBundle/Controller/ContentController.php
@@ -136,7 +136,7 @@ class ContentController extends BaseController
         $configuration->setDescriptionEntity($mapping);
         $contentCollection = $repository->findPaginatedLastVersionByContentTypeAndSite($contentType, $configuration, $siteId);
         $recordsTotal = $repository->countByContentTypeAndSiteInLastVersion($contentType, $siteId);
-        $recordsFiltered = $repository->countByContentTypeAndSiteInLastVersionWithFilter($contentType, $configuration, $siteId);
+        $recordsFiltered = $repository->countByContentTypeInLastVersionWithFilter($contentType, $configuration, $siteId);
 
         $facade = $transformer->transform($contentCollection, $contentType);
         $facade->recordsTotal = $recordsTotal;

--- a/ApiBundle/Controller/ContentController.php
+++ b/ApiBundle/Controller/ContentController.php
@@ -135,8 +135,8 @@ class ContentController extends BaseController
 
         $configuration->setDescriptionEntity($mapping);
         $contentCollection = $repository->findPaginatedLastVersionByContentTypeAndSite($contentType, $configuration, $siteId);
-        $recordsTotal = $repository->countByContentTypeInLastVersion($contentType);
-        $recordsFiltered = $repository->countByContentTypeInLastVersionWithFilter($contentType, $configuration);
+        $recordsTotal = $repository->countByContentTypeAndSiteInLastVersion($contentType, $siteId);
+        $recordsFiltered = $repository->countByContentTypeAndSiteInLastVersionWithFilter($contentType, $configuration, $siteId);
 
         $facade = $transformer->transform($contentCollection, $contentType);
         $facade->recordsTotal = $recordsTotal;


### PR DESCRIPTION
[OO-BUGFIX] Fix elements count in content pagination.
[OO-DEPRECATED] ContentRepository::countByContentTypeInLastVersion method is deprecated since version 1.1.3 and will be removed in 2.0, it is replace by ContentRepository::countByContentTypeAndSiteInLastVersion method.

https://github.com/open-orchestra/open-orchestra-model-interface/pull/212
https://github.com/open-orchestra/open-orchestra-model-bundle/pull/621
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1825