### PR TITLE
fix set currently publish to false when duplicate published content 

### DIFF
--- a/Backoffice/Manager/ContentManager.php
+++ b/Backoffice/Manager/ContentManager.php
@@ -83,6 +83,7 @@ class ContentManager
         $lastVersion = $lastContent !== null ? $lastContent->getVersion() : 0;
         $newContent = clone $content;
         $newContent->setVersion($lastVersion + 1);
+        $newContent->setCurrentlyPublished(false);
         $newContent->setStatus(null);
         foreach ($content->getKeywords() as $keyword) {
             $newContent->addKeyword($keyword);

--- a/Backoffice/Tests/Manager/ContentManagerTest.php
+++ b/Backoffice/Tests/Manager/ContentManagerTest.php
@@ -83,6 +83,7 @@ class ContentManagerTest extends AbstractBaseTestCase
         Phake::verify($newContent)->setVersion($expectedVersion);
         Phake::verify($newContent)->setStatus(null);
         Phake::verify($newContent)->addKeyword($this->keyword);
+        Phake::verify($newContent)->setCurrentlyPublished(false);
         Phake::verify($newContent)->addAttribute($this->contentAttribute);
     }
 


### PR DESCRIPTION
[OO-BUGFIX] Fix currently published when a published content is duplicate
cherry-pick https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1824#issuecomment-234914951