### PR TITLE
remove radio button linked to site when edit content

### DIFF
--- a/Backoffice/EventSubscriber/ContentTypeSubscriber.php
+++ b/Backoffice/EventSubscriber/ContentTypeSubscriber.php
@@ -72,12 +72,21 @@ class ContentTypeSubscriber implements EventSubscriberInterface
      */
     public function preSetData(FormEvent $event)
     {
+        $form = $event->getForm();
         $data = $event->getData();
         $contentType = $this->contentTypeRepository->findOneByContentTypeIdInLastVersion($data->getContentType());
 
         if ($contentType instanceof ContentTypeInterface) {
             $data->setContentTypeVersion($contentType->getVersion());
-            $this->addContentTypeFieldsToForm($contentType->getFields(), $event->getForm(), $data);
+
+            if (null === $data->getId()) {
+                $form->add('linkedToSite', 'checkbox', array(
+                    'label' => 'open_orchestra_backoffice.form.content.linked_to_site',
+                    'required' => false,
+                ));
+            }
+
+            $this->addContentTypeFieldsToForm($contentType->getFields(), $form, $data);
         }
     }
 

--- a/Backoffice/Form/Type/ContentType.php
+++ b/Backoffice/Form/Type/ContentType.php
@@ -38,10 +38,6 @@ class ContentType extends AbstractType
             ->add('keywords', 'oo_keywords_choice', array(
                 'label' => 'open_orchestra_backoffice.form.content.keywords',
                 'required' => false
-            ))
-            ->add('linkedToSite', 'checkbox', array(
-                'label' => 'open_orchestra_backoffice.form.content.linked_to_site',
-                'required' => false,
             ));
 
         $builder->addEventSubscriber($this->contentTypeSubscriber);

--- a/Backoffice/Tests/EventSubscriber/ContentTypeSubscriberTest.php
+++ b/Backoffice/Tests/EventSubscriber/ContentTypeSubscriberTest.php
@@ -164,11 +164,16 @@ class ContentTypeSubscriberTest extends AbstractBaseTestCase
         Phake::when($this->translationChoiceManager)->choose(Phake::anyParameters())->thenReturn($label);
         Phake::when($this->fieldType1)->getType()->thenReturn($type);
         Phake::when($this->fieldType1)->getFormOptions()->thenReturn($options);
+        Phake::when($this->fieldType1)->getId()->thenReturn(null);
 
         $this->subscriber->preSetData($this->event);
 
         Phake::verify($this->repository)->findOneByContentTypeIdInLastVersion($this->contentTypeId);
         Phake::verify($this->content)->setContentTypeVersion($this->contentTypeVersion);
+        Phake::verify($this->form)->add('linkedToSite', 'checkbox', array(
+            'label' => 'open_orchestra_backoffice.form.content.linked_to_site',
+            'required' => false,
+        ));
         Phake::verify($this->form, Phake::times(2))->add($fieldId, $type, $expectedOptions);
     }
 
@@ -215,6 +220,7 @@ class ContentTypeSubscriberTest extends AbstractBaseTestCase
         Phake::when($this->translationChoiceManager)->choose(Phake::anyParameters())->thenReturn($label);
         Phake::when($this->fieldType1)->getType()->thenReturn($type);
         Phake::when($this->fieldType1)->getFormOptions()->thenReturn($options);
+        Phake::when($this->fieldType1)->getId()->thenReturn('fake-id');
 
         Phake::when($this->contentAttribute)->getValue()->thenReturn($realValue);
         Phake::when($this->content)->getAttributeByName($fieldId)->thenReturn($this->contentAttribute);

--- a/Backoffice/Tests/Form/Type/ContentTypeTest.php
+++ b/Backoffice/Tests/Form/Type/ContentTypeTest.php
@@ -56,7 +56,7 @@ class ContentTypeTest extends AbstractBaseTestCase
 
         $this->form->buildForm($builder, array());
 
-        Phake::verify($builder, Phake::times(3))->add(Phake::anyParameters());
+        Phake::verify($builder, Phake::times(2))->add(Phake::anyParameters());
         Phake::verify($builder, Phake::times(1))->addEventSubscriber(Phake::anyParameters());
     }
 


### PR DESCRIPTION
[OO-BUGFIX] Radio button `Link to the current site` is only available when you create a content