### PR TITLE
specify block cache

### DIFF
--- a/ApiBundle/Resources/config/transformer.yml
+++ b/ApiBundle/Resources/config/transformer.yml
@@ -90,6 +90,7 @@ services:
         arguments:
             - '%open_orchestra_api.facade.block.class%'
             - '@open_orchestra_backoffice.display_block_manager'
+            - '@open_orchestra_display.display_block_manager'
             - '@open_orchestra_backoffice.display_icon_manager'
             - '%open_orchestra_model.document.block.class%'
             - '@open_orchestra_backoffice.block_parameter_manager'

--- a/ApiBundle/Tests/Transformer/BlockTransformerTest.php
+++ b/ApiBundle/Tests/Transformer/BlockTransformerTest.php
@@ -60,6 +60,7 @@ class BlockTransformerTest extends AbstractBaseTestCase
         $this->blockTransformer = new BlockTransformer(
             $this->facadeClass,
             $this->displayBlockManager,
+            $this->displayBlockManager,
             $this->displayIconManager,
             $this->blockClass,
             $this->blockParameterManager,
@@ -209,6 +210,7 @@ class BlockTransformerTest extends AbstractBaseTestCase
         $this->blockFacade->nodeId = $facadeNodeId;
         $this->blockFacade->blockId = $blockId;
 
+        Phake::when($this->displayBlockManager)->isPublic(Phake::anyParameters())->thenReturn(false);
         $nodeTransverse = Phake::mock('OpenOrchestra\ModelInterface\Model\NodeInterface');
         Phake::when($this->node)->getNodeId()->thenReturn($nodeId);
         $block = Phake::mock('OpenOrchestra\ModelInterface\Model\BlockInterface');
@@ -229,10 +231,10 @@ class BlockTransformerTest extends AbstractBaseTestCase
     public function blockReverseTransformProvider()
     {
         return array(
-            array('fixture_full', array('blockParameter' => array(), 'blockId' => 5, 'nodeId' => 0), 'fixture_full', 5),
-            array('fixture_full', array('blockParameter' => array(), 'blockId' => 0, 'nodeId' => 0), 'fixture_full', 0),
-            array('fixture_about_us', array('blockParameter' => array(), 'blockId' => 3, 'nodeId' => 'fixture_full'), 'fixture_full', 3),
-            array('fixture_about_us', array('blockParameter' => array('newsId'), 'blockId' => 3, 'nodeId' => 'fixture_full'), 'fixture_full', 3, array('newsId')),
+            array('fixture_full', array('blockParameter' => array(), 'blockId' => 5, 'nodeId' => 0, 'blockPrivate' => true), 'fixture_full', 5),
+            array('fixture_full', array('blockParameter' => array(), 'blockId' => 0, 'nodeId' => 0, 'blockPrivate' => true), 'fixture_full', 0),
+            array('fixture_about_us', array('blockParameter' => array(), 'blockId' => 3, 'nodeId' => 'fixture_full', 'blockPrivate' => true), 'fixture_full', 3),
+            array('fixture_about_us', array('blockParameter' => array('newsId'), 'blockId' => 3, 'nodeId' => 'fixture_full', 'blockPrivate' => true), 'fixture_full', 3, array('newsId')),
         );
     }
 
@@ -249,6 +251,7 @@ class BlockTransformerTest extends AbstractBaseTestCase
         $this->blockFacade->component = $component;
         Phake::when($this->node)->getBlockIndex(Phake::anyParameters())->thenReturn($blockId);
         Phake::when($this->blockParameterManager)->getBlockParameter(Phake::anyParameters())->thenReturn($blockParameter);
+        Phake::when($this->displayBlockManager)->isPublic(Phake::anyParameters())->thenReturn(false);
 
         $expected = $this->blockTransformer->reverseTransformToArray($this->blockFacade, $this->node);
 
@@ -264,9 +267,9 @@ class BlockTransformerTest extends AbstractBaseTestCase
     public function blockReverseTransformProvider2()
     {
         return array(
-            array(array('blockParameter' => array(), 'blockId' => 2, 'nodeId' => 0), 'sample', 2),
-            array(array('blockParameter' => array(), 'blockId' => 3, 'nodeId' => 0), 'menu', 3),
-            array(array('blockParameter' => array('newsId'), 'blockId' => 3, 'nodeId' => 0), 'news', 3, array('newsId')),
+            array(array('blockParameter' => array(), 'blockId' => 2, 'nodeId' => 0, 'blockPrivate' => true), 'sample', 2),
+            array(array('blockParameter' => array(), 'blockId' => 3, 'nodeId' => 0, 'blockPrivate' => true), 'menu', 3),
+            array(array('blockParameter' => array('newsId'), 'blockId' => 3, 'nodeId' => 0, 'blockPrivate' => true), 'news', 3, array('newsId')),
         );
     }
 
@@ -310,10 +313,11 @@ class BlockTransformerTest extends AbstractBaseTestCase
         $this->blockFacade->component = $component;
         Phake::when($this->node)->getBlockIndex(Phake::anyParameters())->thenReturn($blockIndex);
         Phake::when($this->blockParameterManager)->getBlockParameter(Phake::anyParameters())->thenReturn($blockParameter);
+        Phake::when($this->displayBlockManager)->isPublic(Phake::anyParameters())->thenReturn(true);
 
         $result = $this->blockTransformer->reverseTransformToArray($this->blockFacade, $this->node);
 
-        $this->assertSame(array('blockParameter' => $blockParameter, 'blockId' => $blockIndex, 'nodeId' => 0), $result);
+        $this->assertSame(array('blockParameter' => $blockParameter, 'blockId' => $blockIndex, 'nodeId' => 0, 'blockPrivate' => false), $result);
         Phake::verify($this->node)->addBlock(Phake::anyParameters());
         Phake::verify($this->node)->getBlockIndex(Phake::anyParameters());
         Phake::verify($this->generateFormManager)->getDefaultConfiguration(Phake::anyParameters());
@@ -340,7 +344,7 @@ class BlockTransformerTest extends AbstractBaseTestCase
      */
     public function testExceptionTransform()
     {
-        $this->setExpectedException('OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException');
+        $this->expectException('OpenOrchestra\BaseApi\Exceptions\TransformerParameterTypeException');
         $this->blockTransformer->transform(Phake::mock('stdClass'));
     }
 }

--- a/ApiBundle/Transformer/BlockTransformer.php
+++ b/ApiBundle/Transformer/BlockTransformer.php
@@ -27,6 +27,8 @@ class BlockTransformer extends AbstractTransformer
     protected $blockParameterManager;
     protected $generateFormManager;
     protected $displayBlockManager;
+    protected $displayBlockFrontManager;
+    protected $displayIconManager;
     protected $currentSiteManager;
     protected $eventDispatcher;
     protected $nodeRepository;
@@ -37,6 +39,7 @@ class BlockTransformer extends AbstractTransformer
     /**
      * @param string                   $facadeClass
      * @param DisplayBlockManager      $displayBlockManager
+     * @param DisplayBlockManager      $displayBlockFrontManager
      * @param DisplayManager           $displayManager
      * @param string                   $blockClass
      * @param BlockParameterManager    $blockParameterManager
@@ -49,6 +52,7 @@ class BlockTransformer extends AbstractTransformer
     public function __construct(
         $facadeClass,
         DisplayBlockManager $displayBlockManager,
+        DisplayBlockManager $displayBlockFrontManager,
         DisplayManager $displayManager,
         $blockClass,
         BlockParameterManager $blockParameterManager,
@@ -63,6 +67,7 @@ class BlockTransformer extends AbstractTransformer
         $this->blockParameterManager = $blockParameterManager;
         $this->generateFormManager = $generateFormManager;
         $this->displayBlockManager = $displayBlockManager;
+        $this->displayBlockFrontManager = $displayBlockFrontManager;
         $this->displayIconManager = $displayManager;
         $this->nodeRepository = $nodeRepository;
         $this->blockClass = $blockClass;
@@ -186,6 +191,7 @@ class BlockTransformer extends AbstractTransformer
 
         if ($blockElement) {
             $block['blockParameter'] = $this->blockParameterManager->getBlockParameter($blockElement);
+            $block['blockPrivate'] = !$this->displayBlockFrontManager->isPublic($blockElement);
         }
 
         return $block;


### PR DESCRIPTION
[OO-FEATURE] Add a query parameter `cache=private` in the url when a private block is rendering

https://github.com/open-orchestra/open-orchestra-docs/pull/229
https://github.com/open-orchestra/open-orchestra-provision/pull/41
https://github.com/open-orchestra/open-orchestra-model-bundle/pull/636
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1853
https://github.com/open-orchestra/open-orchestra-front-bundle/pull/191