### PR TITLE
1.1 DeleteStatusVoter always return false to avoid long facade generation

### DIFF
--- a/Backoffice/Security/Authorization/Voter/DeleteStatusVoter.php
+++ b/Backoffice/Security/Authorization/Voter/DeleteStatusVoter.php
@@ -71,10 +71,6 @@ class DeleteStatusVoter implements VoterInterface
             return self::ACCESS_ABSTAIN;
         }
 
-        if ($this->usageFinder->hasUsage($object)) {
-            return self::ACCESS_DENIED;
-        }
-
-        return self::ACCESS_GRANTED;
+        return self::ACCESS_DENIED;
     }
 }

--- a/Backoffice/Tests/Security/Authorization/Voter/DeleteStatusVoterTest.php
+++ b/Backoffice/Tests/Security/Authorization/Voter/DeleteStatusVoterTest.php
@@ -115,7 +115,7 @@ class DeleteStatusVoterTest extends AbstractBaseTestCase
     {
         return array(
             array(VoterInterface::ACCESS_DENIED, true),
-            array(VoterInterface::ACCESS_GRANTED, false),
+            array(VoterInterface::ACCESS_DENIED, false),
         );
     }
 }


### PR DESCRIPTION
[OO-HOTFIX] Temporary disable the possibility to delete a status in order to speed up significantly API responses including status