### PR TITLE
Remive nodeId as a paramter on open_orchestra_base_node_preview

### DIFF
--- a/ApiBundle/Transformer/NodeTransformer.php
+++ b/ApiBundle/Transformer/NodeTransformer.php
@@ -239,7 +239,7 @@ class NodeTransformer extends AbstractSecurityCheckerAwareTransformer
             foreach ($site->getAliases() as $aliasId => $alias) {
                 if ($alias->getLanguage() == $node->getLanguage()) {
                     $facade->addPreviewLink(
-                        $this->getPreviewLink($node->getScheme(), $alias, $encryptedId, $aliasId, $node->getId())
+                        $this->getPreviewLink($node->getScheme(), $alias, $encryptedId, $aliasId)
                     );
                 }
             }
@@ -255,11 +255,10 @@ class NodeTransformer extends AbstractSecurityCheckerAwareTransformer
      * @param SiteAliasInterface $alias
      * @param string             $encryptedId
      * @param int                $aliasId
-     * @param string             $nodeId
      *
      * @return FacadeInterface
      */
-    protected function getPreviewLink($scheme, $alias, $encryptedId, $aliasId, $nodeId)
+    protected function getPreviewLink($scheme, $alias, $encryptedId, $aliasId)
     {
         $previewLink = array(
             'name' => $alias->getDomain(),
@@ -273,8 +272,7 @@ class NodeTransformer extends AbstractSecurityCheckerAwareTransformer
         $routeName = 'open_orchestra_base_node_preview';
         $parameters = array(
             'token' => $encryptedId,
-            'aliasId' => $aliasId,
-            'nodeId' => $nodeId
+            'aliasId' => $aliasId
         );
 
         $previewLink['link'] = $domain . $this->generateRoute($routeName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH);


### PR DESCRIPTION
[OO-BCBREAK] Remove a useless parameter on open_orchestra_base_node_preview route
https://github.com/open-orchestra/open-orchestra-base-bundle/pull/117
https://github.com/open-orchestra/open-orchestra-front-bundle/pull/202
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1971