### PR TITLE
remove super admin

### DIFF
--- a/Backoffice/Context/ContextManager.php
+++ b/Backoffice/Context/ContextManager.php
@@ -3,6 +3,7 @@
 namespace OpenOrchestra\Backoffice\Context;
 
 use FOS\UserBundle\Model\GroupableInterface;
+use OpenOrchestra\Backoffice\Security\ContributionRoleInterface;
 use OpenOrchestra\BaseBundle\Context\CurrentSiteIdInterface;
 use OpenOrchestra\ModelInterface\Model\SiteInterface;
 use OpenOrchestra\ModelInterface\Repository\SiteRepositoryInterface;
@@ -102,7 +103,9 @@ class ContextManager implements CurrentSiteIdInterface
         $sites = array();
 
         if ($token && ($user = $token->getUser()) instanceof GroupableInterface) {
-            if ($user->isSuperAdmin()) {
+            if ($user->hasRole(ContributionRoleInterface::DEVELOPER) ||
+                $user->hasRole(ContributionRoleInterface::PLATFORM_ADMIN)
+            ) {
                 return $this->siteRepository->findByDeleted(false);
             }
             foreach ($user->getGroups() as $group) {

--- a/Backoffice/Tests/Context/ContextManagerTest.php
+++ b/Backoffice/Tests/Context/ContextManagerTest.php
@@ -176,7 +176,7 @@ class ContextManagerTest extends AbstractBaseTestCase
         Phake::when($this->siteRepository)->findByDeleted(false)->thenReturn(array($site1, $site2));
 
         $user = Phake::mock('OpenOrchestra\UserBundle\Document\User');
-        Phake::when($user)->isSuperAdmin()->thenReturn(true);
+        Phake::when($user)->hasRole(Phake::anyParameters())->thenReturn(true);
 
         Phake::when($this->token)->getUser()->thenReturn($user);
 

--- a/BackofficeBundle/StrategyManager/AuthorizeStatusChangeManager.php
+++ b/BackofficeBundle/StrategyManager/AuthorizeStatusChangeManager.php
@@ -3,6 +3,7 @@
 namespace OpenOrchestra\BackofficeBundle\StrategyManager;
 
 use OpenOrchestra\Backoffice\AuthorizeStatusChange\AuthorizeStatusChangeInterface;
+use OpenOrchestra\Backoffice\Security\ContributionRoleInterface;
 use OpenOrchestra\ModelInterface\Model\StatusableInterface;
 use OpenOrchestra\ModelInterface\Model\StatusInterface;
 use OpenOrchestra\UserBundle\Model\UserInterface;
@@ -63,7 +64,10 @@ class AuthorizeStatusChangeManager
             throw new AuthenticationCredentialsNotFoundException('The token storage contains no authentication token. One possible reason may be that there is no firewall configured for this URL.');
         }
 
-        if (($user = $token->getUser()) instanceof UserInterface && $user->isSuperAdmin()) {
+        if (($user = $token->getUser()) instanceof UserInterface &&
+             $user->hasRole(ContributionRoleInterface::DEVELOPER) ||
+             $user->hasRole(ContributionRoleInterface::PLATFORM_ADMIN)
+        ) {
             return true;
         }
 

--- a/BackofficeBundle/Tests/StrategyManager/AuthorizeStatusChangeManagerTest.php
+++ b/BackofficeBundle/Tests/StrategyManager/AuthorizeStatusChangeManagerTest.php
@@ -58,7 +58,7 @@ class AuthorizeStatusChangeManagerTest extends AbstractBaseTestCase
     {
         $document = Phake::mock('OpenOrchestra\ModelInterface\Model\StatusableInterface');
         $toStatus = Phake::mock('OpenOrchestra\ModelInterface\Model\StatusInterface');
-        Phake::when($this->user)->isSuperAdmin()->thenReturn(false);
+        Phake::when($this->user)->hasRole(Phake::anyParameters())->thenReturn(false);
 
         Phake::when($this->strategy1)->isGranted(Phake::anyParameters())->thenReturn($isGranted1);
         Phake::when($this->strategy2)->isGranted(Phake::anyParameters())->thenReturn($isGranted2);
@@ -91,7 +91,7 @@ class AuthorizeStatusChangeManagerTest extends AbstractBaseTestCase
         $document = Phake::mock('OpenOrchestra\ModelInterface\Model\StatusableInterface');
         $toStatus = Phake::mock('OpenOrchestra\ModelInterface\Model\StatusInterface');
 
-        Phake::when($this->user)->isSuperAdmin()->thenReturn(true);
+        Phake::when($this->user)->hasRole(Phake::anyParameters())->thenReturn(true);
 
         $this->assertTrue($this->manager->isGranted($document, $toStatus));
     }

--- a/UserAdminBundle/DataFixtures/MongoDB/LoadUserData.php
+++ b/UserAdminBundle/DataFixtures/MongoDB/LoadUserData.php
@@ -19,12 +19,10 @@ class LoadUserData extends AbstractLoadUserData implements OrchestraFunctionalFi
     {
         $developer = $this->generate('developer');
         $developer->addRole(ContributionRoleInterface::DEVELOPER);
-        $developer->addRole(UserInterface::ROLE_SUPER_ADMIN);
         $manager->persist($developer);
 
         $padmin = $this->generate('p-admin');
         $padmin->addRole(ContributionRoleInterface::PLATFORM_ADMIN);
-        $padmin->addRole(UserInterface::ROLE_SUPER_ADMIN);
         $this->addReference('p-admin', $padmin);
         $manager->persist($padmin);
 


### PR DESCRIPTION
[OO-BCBREAK] The use of super admin functionality is removed. use now role DEVELOPER and PLATFORM_ADMIN

https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/2021
https://github.com/open-orchestra/open-orchestra/pull/1104
https://github.com/open-orchestra/open-orchestra-media-admin-bundle/pull/326